### PR TITLE
Add console session token and personal access token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,23 @@ JavaScript HTTP client for the Seam API written in TypeScript.
 
 ## Description
 
-TODO
+[Seam] makes it easy to integrate IoT devices with your applications.
+This is an official SDK for the Seam API.
+Please refer to the official [Seam Docs] to get started.
+
+Parts of this SDK are generated from always up-to-date type information
+provided by [@seamapi/types].
+This ensures all API methods, request shapes, and response shapes are
+accurate and fully typed.
+
+The SDK contains minimal dependencies, is fully tree-shakeable,
+and optimized for use in both client and server applications.
+The underlying HTTP client is [Axios].
+
+[Seam]: https://www.seam.co/
+[Seam Docs]: https://docs.seam.co/latest/
+[@seamapi/types]: https://github.com/seamapi/types/
+[Axios]: https://axios-http.com/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ Obtain one from the Seam Console.
 Use the async factory method to return a client authenticated with a client session token:
 
 ```ts
-const seam = await SeamHttp.fromPublishableKey('your-publishable-key', 'some-user-identifier-key')
+const seam = await SeamHttp.fromPublishableKey(
+  'your-publishable-key',
+  'some-user-identifier-key',
+)
 ```
 
 This will get an existing client session matching the user identifier key,
@@ -132,7 +135,10 @@ const seam = new SeamHttp({
 ##### Use the factory method
 
 ```ts
-const seam = SeamHttp.fromPersonalAccessToken('some-console-session-token', 'your-workspace-id')
+const seam = SeamHttp.fromPersonalAccessToken(
+  'some-console-session-token',
+  'your-workspace-id',
+)
 ```
 
 #### Console Session Token
@@ -154,7 +160,10 @@ const seam = new SeamHttp({
 ##### Use the factory method
 
 ```ts
-const seam = SeamHttp.fromConsoleSessionToken('some-console-session-token', 'your-workspace-id')
+const seam = SeamHttp.fromConsoleSessionToken(
+  'some-console-session-token',
+  'your-workspace-id',
+)
 ```
 
 ## Development and Testing

--- a/README.md
+++ b/README.md
@@ -35,6 +35,112 @@ $ npm install @seamapi/http
 
 [npm]: https://www.npmjs.com/
 
+## Usage
+
+```ts
+import { SeamHttp } from '@seamapi/http'
+
+const seam = new SeamHttp('your-api-key')
+const devices = await seam.devices.list()
+```
+
+### Authentication Methods
+
+The SDK supports several authentication mechanisms.
+Authentication may be configured by passing the corresponding
+options directly to the `SeamHttp` constructor,
+or with the more ergonomic static factory methods.
+
+> Publishable Key authentication is not supported by the constructor
+> and must be configured using `SeamHttp.fromPublishableKey`.
+
+#### API Key
+
+An API key is scoped to a single workspace and should only be used on the server.
+Obtain one from the Seam Console.
+
+- Set the `SEAM_API_KEY` environment variable:
+  ```ts
+  const seam = new SeamHttp()
+  ```
+- Pass as the first argument to the constructor:
+  ```ts
+  const seam = new SeamHttp('your-api-key')
+  ```
+- Pass as an option the constructor:
+  ```ts
+  const seam = new SeamHttp({ apiKey: 'your-api-key' })
+  ```
+- Use the factory method:
+  ```ts
+  const seam = SeamHttp.fromApiKey('your-api-key')
+  ```
+
+#### Client Session Token
+
+A Client Session Token is scoped to a client session and should only be used on the client.
+
+- Pass as an option the constructor:
+  ```ts
+  const seam = new SeamHttp({ clientSessionToken: 'some-client-session-token' })
+  ```
+- Use the factory method:
+  ```ts
+  const seam = SeamHttp.fromClientSessionToken('some-client-session-token')
+  ```
+
+#### Publishable Key
+
+A Publishable Key is used by the client to acquire Client Session Token for a workspace.
+Obtain one from the Seam Console.
+
+Use the async factory method to return a client authenticated with a client session token:
+
+```ts
+const seam = await SeamHttp.fromPublishableKey('your-publishable-key', 'some-user-identifier-key')
+```
+
+This will get an existing client session matching the user identifier key,
+or create a new empty client session.
+
+#### Personal Access Token
+
+A Personal Access Token is scoped to a Seam Console user.
+Obtain one from the Seam Console.
+A workspace id must be provided when using this method
+and all requests will be scoped to that workspace.
+
+- Pass as an option the constructor:
+  ```ts
+  const seam = new SeamHttp({
+    personalAccessToken: 'your-personal-access-token',
+    workspaceId: 'your-workspace-id',
+  })
+  ```
+- Use the factory method:
+  ```ts
+  const seam = SeamHttp.fromPersonalAccessToken('some-console-session-token', 'your-workspace-id')
+  ```
+
+#### Console Session Token
+
+A Console Session Token is used by the Seam Console.
+This authentication method is only used by internal Seam applications.
+A workspace id must be provided when using this method
+and all requests will be scoped to that workspace.
+
+- Pass as an option the constructor:
+  ```ts
+  const seam = new SeamHttp({
+    consoleSessionToken: 'some-console-session-token',
+    workspaceId: 'your-workspace-id',
+  })
+  ```
+- Use the factory method:
+  ```ts
+  const seam = SeamHttp.fromConsoleSessionToken('some-console-session-token', 'your-workspace-id')
+  ```
+
 ## Development and Testing
 
 ### Quickstart

--- a/README.md
+++ b/README.md
@@ -59,35 +59,45 @@ or with the more ergonomic static factory methods.
 An API key is scoped to a single workspace and should only be used on the server.
 Obtain one from the Seam Console.
 
-- Set the `SEAM_API_KEY` environment variable:
-  ```ts
-  const seam = new SeamHttp()
-  ```
-- Pass as the first argument to the constructor:
-  ```ts
-  const seam = new SeamHttp('your-api-key')
-  ```
-- Pass as an option the constructor:
-  ```ts
-  const seam = new SeamHttp({ apiKey: 'your-api-key' })
-  ```
-- Use the factory method:
-  ```ts
-  const seam = SeamHttp.fromApiKey('your-api-key')
-  ```
+##### Set the `SEAM_API_KEY` environment variable
+
+```ts
+const seam = new SeamHttp()
+```
+
+##### Pass as the first argument to the constructor
+
+```ts
+const seam = new SeamHttp('your-api-key')
+```
+
+##### Pass as an option the constructor
+
+```ts
+const seam = new SeamHttp({ apiKey: 'your-api-key' })
+```
+
+##### Use the factory method
+
+```ts
+const seam = SeamHttp.fromApiKey('your-api-key')
+```
 
 #### Client Session Token
 
 A Client Session Token is scoped to a client session and should only be used on the client.
 
-- Pass as an option the constructor:
-  ```ts
-  const seam = new SeamHttp({ clientSessionToken: 'some-client-session-token' })
-  ```
-- Use the factory method:
-  ```ts
-  const seam = SeamHttp.fromClientSessionToken('some-client-session-token')
-  ```
+##### Pass as an option the constructor
+
+```ts
+const seam = new SeamHttp({ clientSessionToken: 'some-client-session-token' })
+```
+
+##### Use the factory method
+
+```ts
+const seam = SeamHttp.fromClientSessionToken('some-client-session-token')
+```
 
 #### Publishable Key
 
@@ -110,17 +120,20 @@ Obtain one from the Seam Console.
 A workspace id must be provided when using this method
 and all requests will be scoped to that workspace.
 
-- Pass as an option the constructor:
-  ```ts
-  const seam = new SeamHttp({
-    personalAccessToken: 'your-personal-access-token',
-    workspaceId: 'your-workspace-id',
-  })
-  ```
-- Use the factory method:
-  ```ts
-  const seam = SeamHttp.fromPersonalAccessToken('some-console-session-token', 'your-workspace-id')
-  ```
+##### Pass as an option the constructor
+
+```ts
+const seam = new SeamHttp({
+  personalAccessToken: 'your-personal-access-token',
+  workspaceId: 'your-workspace-id',
+})
+```
+
+##### Use the factory method
+
+```ts
+const seam = SeamHttp.fromPersonalAccessToken('some-console-session-token', 'your-workspace-id')
+```
 
 #### Console Session Token
 
@@ -129,17 +142,20 @@ This authentication method is only used by internal Seam applications.
 A workspace id must be provided when using this method
 and all requests will be scoped to that workspace.
 
-- Pass as an option the constructor:
-  ```ts
-  const seam = new SeamHttp({
-    consoleSessionToken: 'some-console-session-token',
-    workspaceId: 'your-workspace-id',
-  })
-  ```
-- Use the factory method:
-  ```ts
-  const seam = SeamHttp.fromConsoleSessionToken('some-console-session-token', 'your-workspace-id')
-  ```
+##### Pass as an option the constructor
+
+```ts
+const seam = new SeamHttp({
+  consoleSessionToken: 'some-console-session-token',
+  workspaceId: 'your-workspace-id',
+})
+```
+
+##### Use the factory method
+
+```ts
+const seam = SeamHttp.fromConsoleSessionToken('some-console-session-token', 'your-workspace-id')
+```
 
 ## Development and Testing
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -244,6 +244,7 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
@@ -251,6 +252,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessTokenToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -252,7 +252,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
-  type SeamHttpOptionsWithPersonalAccessTokenToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -250,6 +250,7 @@ import {
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -243,6 +243,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/auth.ts
+++ b/src/lib/seam/connect/auth.ts
@@ -112,9 +112,9 @@ const getAuthHeadersForConsoleSessionToken = ({
   consoleSessionToken,
   workspaceId,
 }: SeamHttpOptionsWithConsoleSessionToken): Headers => {
-  if (isJwt(consoleSessionToken)) {
+  if (isAccessToken(consoleSessionToken)) {
     throw new SeamHttpInvalidTokenError(
-      'A JWT cannot be used as a consoleSessionToken',
+      'An Access Token cannot be used as a consoleSessionToken',
     )
   }
 
@@ -130,9 +130,9 @@ const getAuthHeadersForConsoleSessionToken = ({
     )
   }
 
-  if (!isAccessToken(consoleSessionToken)) {
+  if (!isJwt(consoleSessionToken)) {
     throw new SeamHttpInvalidTokenError(
-      `Unknown or invalid consoleSessionToken format, expected token to start with ${accessTokenPrefix}`,
+      `Unknown or invalid consoleSessionToken format, expected a JWT which starts with ${jwtPrefix}`,
     )
   }
 

--- a/src/lib/seam/connect/auth.ts
+++ b/src/lib/seam/connect/auth.ts
@@ -126,7 +126,7 @@ const getAuthHeadersForConsoleSessionToken = ({
 
   if (isPublishableKey(consoleSessionToken)) {
     throw new SeamHttpInvalidTokenError(
-      'A Publishable Key cannot be used as a clientSessionToken',
+      'A Publishable Key cannot be used as a consoleSessionToken',
     )
   }
 

--- a/src/lib/seam/connect/auth.ts
+++ b/src/lib/seam/connect/auth.ts
@@ -153,6 +153,10 @@ export const warnOnInsecureuserIdentifierKey = (
 
 const tokenPrefix = 'seam_'
 
+const accessTokenPrefix = 'seam_at'
+
+const jwtPrefix = 'ey'
+
 const clientSessionTokenPrefix = 'seam_cst'
 
 const publishableKeyTokenPrefix = 'seam_pk'
@@ -160,9 +164,10 @@ const publishableKeyTokenPrefix = 'seam_pk'
 const isClientSessionToken = (token: string): boolean =>
   token.startsWith(clientSessionTokenPrefix)
 
-const isAccessToken = (token: string): boolean => token.startsWith('seam_at')
+const isAccessToken = (token: string): boolean =>
+  token.startsWith(accessTokenPrefix)
 
-const isJwt = (token: string): boolean => token.startsWith('ey')
+const isJwt = (token: string): boolean => token.startsWith(jwtPrefix)
 
 const isSeamToken = (token: string): boolean => token.startsWith(tokenPrefix)
 

--- a/src/lib/seam/connect/options.ts
+++ b/src/lib/seam/connect/options.ts
@@ -5,6 +5,7 @@ export type SeamHttpOptions =
   | SeamHttpOptionsWithClient
   | SeamHttpOptionsWithApiKey
   | SeamHttpOptionsWithClientSessionToken
+  | SeamHttpOptionsWithConsoleSessionToken
 
 interface SeamHttpCommonOptions extends ClientOptions {
   endpoint?: string
@@ -53,6 +54,12 @@ export const isSeamHttpOptionsWithApiKey = (
     )
   }
 
+  if ('consoleSessionToken' in options && options.consoleSessionToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The consoleSessionToken option cannot be used with the apiKey option',
+    )
+  }
+
   return true
 }
 
@@ -69,7 +76,40 @@ export const isSeamHttpOptionsWithClientSessionToken = (
 
   if ('apiKey' in options && options.apiKey != null) {
     throw new SeamHttpInvalidOptionsError(
-      'The clientSessionToken option cannot be used with the apiKey option',
+      'The apiKey option cannot be used with the clientSessionToken option',
+    )
+  }
+
+  if ('consoleSessionToken' in options && options.consoleSessionToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The consoleSessionToken option cannot be used with the clientSessionToken option',
+    )
+  }
+
+  return true
+}
+
+export interface SeamHttpOptionsWithConsoleSessionToken
+  extends SeamHttpCommonOptions {
+  consoleSessionToken: string
+  workspaceId: string
+}
+
+export const isSeamHttpOptionsWithConsoleSessionToken = (
+  options: SeamHttpOptions,
+): options is SeamHttpOptionsWithConsoleSessionToken => {
+  if (!('consoleSessionToken' in options)) return false
+  if (options.consoleSessionToken == null) return false
+
+  if ('apiKey' in options && options.apiKey != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The apiKey option cannot be used with the consoleSessionToken option',
+    )
+  }
+
+  if ('clientSessionToken' in options && options.clientSessionToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The clientSessionToken option cannot be used with the consoleSessionToken option',
     )
   }
 

--- a/src/lib/seam/connect/options.ts
+++ b/src/lib/seam/connect/options.ts
@@ -6,6 +6,7 @@ export type SeamHttpOptions =
   | SeamHttpOptionsWithApiKey
   | SeamHttpOptionsWithClientSessionToken
   | SeamHttpOptionsWithConsoleSessionToken
+  | SeamHttpOptionsWithPersonalAccessToken
 
 interface SeamHttpCommonOptions extends ClientOptions {
   endpoint?: string
@@ -60,6 +61,12 @@ export const isSeamHttpOptionsWithApiKey = (
     )
   }
 
+  if ('personalAccessToken' in options && options.personalAccessToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The personalAccessToken option cannot be used with the apiKey option',
+    )
+  }
+
   return true
 }
 
@@ -83,6 +90,12 @@ export const isSeamHttpOptionsWithClientSessionToken = (
   if ('consoleSessionToken' in options && options.consoleSessionToken != null) {
     throw new SeamHttpInvalidOptionsError(
       'The consoleSessionToken option cannot be used with the clientSessionToken option',
+    )
+  }
+
+  if ('personalAccessToken' in options && options.personalAccessToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The personalAccessToken option cannot be used with the clientSessionToken option',
     )
   }
 
@@ -116,6 +129,51 @@ export const isSeamHttpOptionsWithConsoleSessionToken = (
   if ('clientSessionToken' in options && options.clientSessionToken != null) {
     throw new SeamHttpInvalidOptionsError(
       'The clientSessionToken option cannot be used with the consoleSessionToken option',
+    )
+  }
+
+  if ('personalAccessToken' in options && options.personalAccessToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The personalAccessToken option cannot be used with the consoleSessionToken option',
+    )
+  }
+
+  return true
+}
+
+export interface SeamHttpOptionsWithPersonalAccessToken
+  extends SeamHttpCommonOptions {
+  personalAccessToken: string
+  workspaceId: string
+}
+
+export const isSeamHttpOptionsWithPersonalAccessToken = (
+  options: SeamHttpOptions,
+): options is SeamHttpOptionsWithPersonalAccessToken => {
+  if (!('personalAccessToken' in options)) return false
+  if (options.personalAccessToken == null) return false
+
+  if (!('workspaceId' in options) || options.workspaceId == null) {
+    throw new SeamHttpInvalidOptionsError(
+      'Must pass a workspaceId when using a personalAccessToken',
+    )
+  }
+
+  if ('apiKey' in options && options.apiKey != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The apiKey option cannot be used with the personalAccessToken option',
+    )
+  }
+
+  if ('clientSessionToken' in options && options.clientSessionToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The clientSessionToken option cannot be used with the personalAccessToken option',
+    )
+  }
+
+  if ('consoleSessionToken' in options && options.consoleSessionToken != null) {
+    throw new SeamHttpInvalidOptionsError(
+      'The consoleSessionToken option cannot be used with the personalAccessToken option',
     )
   }
 

--- a/src/lib/seam/connect/options.ts
+++ b/src/lib/seam/connect/options.ts
@@ -101,6 +101,12 @@ export const isSeamHttpOptionsWithConsoleSessionToken = (
   if (!('consoleSessionToken' in options)) return false
   if (options.consoleSessionToken == null) return false
 
+  if (!('workspaceId' in options) || options.workspaceId == null) {
+    throw new SeamHttpInvalidOptionsError(
+      'Must pass a workspaceId when using a consoleSessionToken',
+    )
+  }
+
   if ('apiKey' in options && options.apiKey != null) {
     throw new SeamHttpInvalidOptionsError(
       'The apiKey option cannot be used with the consoleSessionToken option',

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpAccessCodesUnmanaged {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAccessCodesUnmanaged(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAccessCodesUnmanaged {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAccessCodesUnmanaged(constructorOptions)

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -82,6 +82,23 @@ export class SeamHttpAccessCodesUnmanaged {
     return SeamHttpAccessCodesUnmanaged.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAccessCodesUnmanaged {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAccessCodesUnmanaged(constructorOptions)
+  }
+
   async convertToManaged(
     body?: AccessCodesUnmanagedConvertToManagedBody,
   ): Promise<void> {

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -96,6 +98,23 @@ export class SeamHttpAccessCodes {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAccessCodes(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAccessCodes {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAccessCodes(constructorOptions)

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -83,6 +83,23 @@ export class SeamHttpAccessCodes {
     return SeamHttpAccessCodes.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAccessCodes {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAccessCodes(constructorOptions)
+  }
+
   get unmanaged(): SeamHttpAccessCodesUnmanaged {
     return SeamHttpAccessCodesUnmanaged.fromClient(this.client)
   }

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -82,6 +82,23 @@ export class SeamHttpAcsAccessGroups {
     return SeamHttpAcsAccessGroups.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsAccessGroups {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsAccessGroups(constructorOptions)
+  }
+
   async addUser(body?: AcsAccessGroupsAddUserBody): Promise<void> {
     await this.client.request<AcsAccessGroupsAddUserResponse>({
       url: '/acs/access_groups/add_user',

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpAcsAccessGroups {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsAccessGroups(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsAccessGroups {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAcsAccessGroups(constructorOptions)

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -82,6 +82,23 @@ export class SeamHttpAcsCredentials {
     return SeamHttpAcsCredentials.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsCredentials {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsCredentials(constructorOptions)
+  }
+
   async create(
     body?: AcsCredentialsCreateBody,
   ): Promise<AcsCredentialsCreateResponse['acs_credential']> {

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpAcsCredentials {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsCredentials(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsCredentials {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAcsCredentials(constructorOptions)

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -82,6 +82,23 @@ export class SeamHttpAcsSystems {
     return SeamHttpAcsSystems.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsSystems {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsSystems(constructorOptions)
+  }
+
   async get(
     body?: AcsSystemsGetParams,
   ): Promise<AcsSystemsGetResponse['acs_system']> {

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpAcsSystems {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsSystems(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsSystems {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAcsSystems(constructorOptions)

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpAcsUsers {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsUsers(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsUsers {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAcsUsers(constructorOptions)

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -82,6 +82,23 @@ export class SeamHttpAcsUsers {
     return SeamHttpAcsUsers.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcsUsers {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcsUsers(constructorOptions)
+  }
+
   async addToAccessGroup(body?: AcsUsersAddToAccessGroupBody): Promise<void> {
     await this.client.request<AcsUsersAddToAccessGroupResponse>({
       url: '/acs/users/add_to_access_group',

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -18,6 +18,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -9,6 +9,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -83,6 +83,23 @@ export class SeamHttpAcs {
     return SeamHttpAcs.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcs {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcs(constructorOptions)
+  }
+
   get accessGroups(): SeamHttpAcsAccessGroups {
     return SeamHttpAcsAccessGroups.fromClient(this.client)
   }

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -10,12 +10,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -96,6 +98,23 @@ export class SeamHttpAcs {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpAcs(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpAcs {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpAcs(constructorOptions)

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -82,6 +82,23 @@ export class SeamHttpActionAttempts {
     return SeamHttpActionAttempts.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpActionAttempts {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpActionAttempts(constructorOptions)
+  }
+
   async get(
     body?: ActionAttemptsGetParams,
   ): Promise<ActionAttemptsGetResponse['action_attempt']> {

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpActionAttempts {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpActionAttempts(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpActionAttempts {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpActionAttempts(constructorOptions)

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -93,6 +95,23 @@ export class SeamHttpClientSessions {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpClientSessions(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpClientSessions {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpClientSessions(constructorOptions)

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -80,6 +80,23 @@ export class SeamHttpClientSessions {
     return SeamHttpClientSessions.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpClientSessions {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpClientSessions(constructorOptions)
+  }
+
   async create(
     body?: ClientSessionsCreateBody,
   ): Promise<ClientSessionsCreateResponse['client_session']> {

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -16,6 +16,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -17,12 +17,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -99,6 +101,23 @@ export class SeamHttpConnectWebviews {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpConnectWebviews(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpConnectWebviews {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpConnectWebviews(constructorOptions)

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -25,6 +25,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -86,6 +86,23 @@ export class SeamHttpConnectWebviews {
     return SeamHttpConnectWebviews.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpConnectWebviews {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpConnectWebviews(constructorOptions)
+  }
+
   async create(
     body?: ConnectWebviewsCreateBody,
   ): Promise<ConnectWebviewsCreateResponse['connect_webview']> {

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -16,6 +16,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -86,6 +86,23 @@ export class SeamHttpConnectedAccounts {
     return SeamHttpConnectedAccounts.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpConnectedAccounts {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpConnectedAccounts(constructorOptions)
+  }
+
   async delete(body?: ConnectedAccountsDeleteBody): Promise<void> {
     await this.client.request<ConnectedAccountsDeleteResponse>({
       url: '/connected_accounts/delete',

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -17,12 +17,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -99,6 +101,23 @@ export class SeamHttpConnectedAccounts {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpConnectedAccounts(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpConnectedAccounts {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpConnectedAccounts(constructorOptions)

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -25,6 +25,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpDevicesUnmanaged {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpDevicesUnmanaged(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpDevicesUnmanaged {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpDevicesUnmanaged(constructorOptions)

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -82,6 +82,23 @@ export class SeamHttpDevicesUnmanaged {
     return SeamHttpDevicesUnmanaged.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpDevicesUnmanaged {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpDevicesUnmanaged(constructorOptions)
+  }
+
   async get(
     body?: DevicesUnmanagedGetParams,
   ): Promise<DevicesUnmanagedGetResponse['device']> {

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -96,6 +98,23 @@ export class SeamHttpDevices {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpDevices(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpDevices {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpDevices(constructorOptions)

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -83,6 +83,23 @@ export class SeamHttpDevices {
     return SeamHttpDevices.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpDevices {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpDevices(constructorOptions)
+  }
+
   get unmanaged(): SeamHttpDevicesUnmanaged {
     return SeamHttpDevicesUnmanaged.fromClient(this.client)
   }

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpEvents {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpEvents(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpEvents {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpEvents(constructorOptions)

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -82,6 +82,23 @@ export class SeamHttpEvents {
     return SeamHttpEvents.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpEvents {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpEvents(constructorOptions)
+  }
+
   async get(body?: EventsGetParams): Promise<EventsGetResponse['event']> {
     const { data } = await this.client.request<EventsGetResponse>({
       url: '/events/get',

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -95,6 +97,23 @@ export class SeamHttpLocks {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpLocks(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpLocks {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpLocks(constructorOptions)

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -82,6 +82,23 @@ export class SeamHttpLocks {
     return SeamHttpLocks.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpLocks {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpLocks(constructorOptions)
+  }
+
   async get(body?: LocksGetParams): Promise<LocksGetResponse['device']> {
     const { data } = await this.client.request<LocksGetResponse>({
       url: '/locks/get',

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -85,6 +85,23 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     )
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpNoiseSensorsNoiseThresholds {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpNoiseSensorsNoiseThresholds(constructorOptions)
+  }
+
   async create(body?: NoiseSensorsNoiseThresholdsCreateBody): Promise<void> {
     await this.client.request<NoiseSensorsNoiseThresholdsCreateResponse>({
       url: '/noise_sensors/noise_thresholds/create',

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -98,6 +100,23 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpNoiseSensorsNoiseThresholds(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpNoiseSensorsNoiseThresholds {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpNoiseSensorsNoiseThresholds(constructorOptions)

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -18,6 +18,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -10,12 +10,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -93,6 +95,23 @@ export class SeamHttpNoiseSensors {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpNoiseSensors(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpNoiseSensors {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpNoiseSensors(constructorOptions)

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -9,6 +9,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -80,6 +80,23 @@ export class SeamHttpNoiseSensors {
     return SeamHttpNoiseSensors.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpNoiseSensors {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpNoiseSensors(constructorOptions)
+  }
+
   get noiseThresholds(): SeamHttpNoiseSensorsNoiseThresholds {
     return SeamHttpNoiseSensorsNoiseThresholds.fromClient(this.client)
   }

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -85,6 +85,23 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     )
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpThermostatsClimateSettingSchedules {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpThermostatsClimateSettingSchedules(constructorOptions)
+  }
+
   async create(
     body?: ThermostatsClimateSettingSchedulesCreateBody,
   ): Promise<

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -98,6 +100,23 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpThermostatsClimateSettingSchedules(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpThermostatsClimateSettingSchedules {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpThermostatsClimateSettingSchedules(constructorOptions)

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -21,6 +21,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -83,6 +83,23 @@ export class SeamHttpThermostats {
     return SeamHttpThermostats.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpThermostats {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpThermostats(constructorOptions)
+  }
+
   get climateSettingSchedules(): SeamHttpThermostatsClimateSettingSchedules {
     return SeamHttpThermostatsClimateSettingSchedules.fromClient(this.client)
   }

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -12,6 +12,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -13,12 +13,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -96,6 +98,23 @@ export class SeamHttpThermostats {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpThermostats(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpThermostats {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpThermostats(constructorOptions)

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -16,6 +16,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -86,6 +86,23 @@ export class SeamHttpWebhooks {
     return SeamHttpWebhooks.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpWebhooks {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpWebhooks(constructorOptions)
+  }
+
   async create(
     body?: WebhooksCreateBody,
   ): Promise<WebhooksCreateResponse['webhook']> {

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -17,12 +17,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -99,6 +101,23 @@ export class SeamHttpWebhooks {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpWebhooks(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpWebhooks {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpWebhooks(constructorOptions)

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -25,6 +25,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -16,6 +16,7 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -17,12 +17,14 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -99,6 +101,23 @@ export class SeamHttpWorkspaces {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpWorkspaces(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpWorkspaces {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttpWorkspaces(constructorOptions)

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -86,6 +86,23 @@ export class SeamHttpWorkspaces {
     return SeamHttpWorkspaces.fromClientSessionToken(token, options)
   }
 
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttpWorkspaces {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttpWorkspaces(constructorOptions)
+  }
+
   async get(
     params?: WorkspacesGetParams,
   ): Promise<WorkspacesGetResponse['workspace']> {

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -25,6 +25,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -5,6 +5,7 @@ import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
   isSeamHttpOptionsWithConsoleSessionToken,
+  isSeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
@@ -12,6 +13,7 @@ import {
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
+  type SeamHttpOptionsWithPersonalAccessToken,
 } from './options.js'
 import { parseOptions } from './parse-options.js'
 import {
@@ -101,6 +103,23 @@ export class SeamHttp {
     if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
       throw new SeamHttpInvalidOptionsError(
         'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttp(constructorOptions)
+  }
+
+  static fromPersonalAccessToken(
+    personalAccessToken: SeamHttpOptionsWithPersonalAccessToken['personalAccessToken'],
+    workspaceId: SeamHttpOptionsWithPersonalAccessToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithPersonalAccessToken,
+      'personalAccessToken' | 'workspaceId'
+    > = {},
+  ): SeamHttp {
+    const constructorOptions = { ...options, personalAccessToken, workspaceId }
+    if (!isSeamHttpOptionsWithPersonalAccessToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing personalAccessToken or workspaceId',
       )
     }
     return new SeamHttp(constructorOptions)

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -4,12 +4,14 @@ import {
   isSeamHttpOptionsWithApiKey,
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
+  isSeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpFromPublishableKeyOptions,
   SeamHttpInvalidOptionsError,
   type SeamHttpOptions,
   type SeamHttpOptionsWithApiKey,
   type SeamHttpOptionsWithClient,
   type SeamHttpOptionsWithClientSessionToken,
+  type SeamHttpOptionsWithConsoleSessionToken,
 } from './options.js'
 import { parseOptions } from './parse-options.js'
 import {
@@ -85,6 +87,23 @@ export class SeamHttp {
       user_identifier_key: userIdentifierKey,
     })
     return SeamHttp.fromClientSessionToken(token, options)
+  }
+
+  static fromConsoleSessionToken(
+    consoleSessionToken: SeamHttpOptionsWithConsoleSessionToken['consoleSessionToken'],
+    workspaceId: SeamHttpOptionsWithConsoleSessionToken['workspaceId'],
+    options: Omit<
+      SeamHttpOptionsWithConsoleSessionToken,
+      'consoleSessionToken' | 'workspaceId'
+    > = {},
+  ): SeamHttp {
+    const constructorOptions = { ...options, consoleSessionToken, workspaceId }
+    if (!isSeamHttpOptionsWithConsoleSessionToken(constructorOptions)) {
+      throw new SeamHttpInvalidOptionsError(
+        'Missing consoleSessionToken or workspaceId',
+      )
+    }
+    return new SeamHttp(constructorOptions)
   }
 
   get accessCodes(): SeamHttpAccessCodes {

--- a/test/seam/connect/console-session-token.test.ts
+++ b/test/seam/connect/console-session-token.test.ts
@@ -1,0 +1,73 @@
+import test from 'ava'
+import { getTestServer } from 'fixtures/seam/connect/api.js'
+
+import { SeamHttp } from '@seamapi/http/connect'
+
+import { SeamHttpInvalidTokenError } from 'lib/seam/connect/auth.js'
+
+// UPSTREAM: Fake does not support JWT.
+// https://github.com/seamapi/fake-seam-connect/issues/124
+test.failing(
+  'SeamHttp: fromConsoleSessionToken returns instance authorized with consoleSessionToken',
+  async (t) => {
+    const { seed, endpoint } = await getTestServer(t)
+    const seam = SeamHttp.fromConsoleSessionToken(
+      'ey_TODO',
+      seed.seed_workspace_1,
+      {
+        endpoint,
+      },
+    )
+    const device = await seam.devices.get({
+      device_id: seed.august_device_1,
+    })
+    t.is(device.workspace_id, seed.seed_workspace_1)
+    t.is(device.device_id, seed.august_device_1)
+  },
+)
+
+// UPSTREAM: Fake does not support JWT.
+// https://github.com/seamapi/fake-seam-connect/issues/124
+test.failing(
+  'SeamHttp: constructor returns instance authorized with consoleSessionToken',
+  async (t) => {
+    const { seed, endpoint } = await getTestServer(t)
+    const seam = new SeamHttp({
+      consoleSessionToken: 'ey_TODO',
+      workspaceId: seed.seed_workspace_1,
+      endpoint,
+    })
+    const device = await seam.devices.get({
+      device_id: seed.august_device_1,
+    })
+    t.is(device.workspace_id, seed.seed_workspace_1)
+    t.is(device.device_id, seed.august_device_1)
+  },
+)
+
+test('SeamHttp: checks consoleSessionToken format', (t) => {
+  const workspaceId = 'e4203e37-e569-4a5a-bfb7-e3e8de66161d'
+  t.throws(
+    () =>
+      SeamHttp.fromConsoleSessionToken('some-invalid-key-format', workspaceId),
+    {
+      instanceOf: SeamHttpInvalidTokenError,
+      message: /Unknown/,
+    },
+  )
+  t.throws(
+    () => SeamHttp.fromConsoleSessionToken('seam_apikey_token', workspaceId),
+    {
+      instanceOf: SeamHttpInvalidTokenError,
+      message: /Unknown/,
+    },
+  )
+  t.throws(() => SeamHttp.fromConsoleSessionToken('seam_cst', workspaceId), {
+    instanceOf: SeamHttpInvalidTokenError,
+    message: /Client Session Token/,
+  })
+  t.throws(() => SeamHttp.fromConsoleSessionToken('seam_at', workspaceId), {
+    instanceOf: SeamHttpInvalidTokenError,
+    message: /Access Token/,
+  })
+})

--- a/test/seam/connect/personal-access-token.test.ts
+++ b/test/seam/connect/personal-access-token.test.ts
@@ -1,0 +1,73 @@
+import test from 'ava'
+import { getTestServer } from 'fixtures/seam/connect/api.js'
+
+import { SeamHttp } from '@seamapi/http/connect'
+
+import { SeamHttpInvalidTokenError } from 'lib/seam/connect/auth.js'
+
+// UPSTREAM: Fake does not support personal access token.
+// https://github.com/seamapi/fake-seam-connect/issues/126
+test.failing(
+  'SeamHttp: fromPersonalAccessToken returns instance authorized with personalAccessToken',
+  async (t) => {
+    const { seed, endpoint } = await getTestServer(t)
+    const seam = SeamHttp.fromPersonalAccessToken(
+      'at_TODO',
+      seed.seed_workspace_1,
+      {
+        endpoint,
+      },
+    )
+    const device = await seam.devices.get({
+      device_id: seed.august_device_1,
+    })
+    t.is(device.workspace_id, seed.seed_workspace_1)
+    t.is(device.device_id, seed.august_device_1)
+  },
+)
+
+// UPSTREAM: Fake does not support personal access token.
+// https://github.com/seamapi/fake-seam-connect/issues/126
+test.failing(
+  'SeamHttp: constructor returns instance authorized with personalAccessToken',
+  async (t) => {
+    const { seed, endpoint } = await getTestServer(t)
+    const seam = new SeamHttp({
+      personalAccessToken: 'at_TODO',
+      workspaceId: seed.seed_workspace_1,
+      endpoint,
+    })
+    const device = await seam.devices.get({
+      device_id: seed.august_device_1,
+    })
+    t.is(device.workspace_id, seed.seed_workspace_1)
+    t.is(device.device_id, seed.august_device_1)
+  },
+)
+
+test('SeamHttp: checks personalAccessToken format', (t) => {
+  const workspaceId = 'e4203e37-e569-4a5a-bfb7-e3e8de66161d'
+  t.throws(
+    () =>
+      SeamHttp.fromPersonalAccessToken('some-invalid-key-format', workspaceId),
+    {
+      instanceOf: SeamHttpInvalidTokenError,
+      message: /Unknown/,
+    },
+  )
+  t.throws(
+    () => SeamHttp.fromPersonalAccessToken('seam_apikey_token', workspaceId),
+    {
+      instanceOf: SeamHttpInvalidTokenError,
+      message: /Unknown/,
+    },
+  )
+  t.throws(() => SeamHttp.fromPersonalAccessToken('seam_cst', workspaceId), {
+    instanceOf: SeamHttpInvalidTokenError,
+    message: /Client Session Token/,
+  })
+  t.throws(() => SeamHttp.fromPersonalAccessToken('ey', workspaceId), {
+    instanceOf: SeamHttpInvalidTokenError,
+    message: /JWT/,
+  })
+})


### PR DESCRIPTION
- Move token prefixes to const
- Add SeamHttp.fromConsoleSessionToken
- Add consoleSessionToken tests
- ci: Generate code
- Check for workspaceId with consoleSessionToken
- Add SeamHttpOptionsWithPersonalAccessToken
- Add missing import
- ci: Generate code
