### PR TITLE
feat: Add default client request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Some asynchronous operations, e.g., unlocking a door, return an [action attempt]
 Seam tracks the progress of requested operation and updates the action attempt.
 
 To make working with action attempts more convenient for applications,
-this library provides the `waitForActionAttempt` option:
+this library provides the `waitForActionAttempt` option.
+
+Pass the option per-request,
 
 ```ts
 await seam.locks.unlockDoor(
@@ -160,6 +162,17 @@ await seam.locks.unlockDoor(
     waitForActionAttempt: true,
   },
 )
+```
+
+or set the default option for the client:
+
+```ts
+const seam = new SeamHttp({
+  apiKey: 'your-api-key',
+  waitForActionAttempt: true,
+})
+
+await seam.locks.unlockDoor({ device_id })
 ```
 
 Using the `waitForActionAttempt` option:

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -256,7 +256,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions
+} from 'lib/seam/connect/parse-options.js'
 import {
   resolveActionAttempt,
 } from 'lib/seam/connect/resolve-action-attempt.js'

--- a/src/lib/seam/connect/client.ts
+++ b/src/lib/seam/connect/client.ts
@@ -12,14 +12,11 @@ export type Client = AxiosInstance
 export interface ClientOptions {
   axiosOptions?: AxiosRequestConfig
   axiosRetryOptions?: AxiosRetryConfig
-  client?: Client
 }
 
 type AxiosRetryConfig = Parameters<AxiosRetry>[1]
 
 export const createClient = (options: ClientOptions): AxiosInstance => {
-  if (options.client != null) return options.client
-
   const client = axios.create({
     paramsSerializer,
     ...options.axiosOptions,

--- a/src/lib/seam/connect/options.ts
+++ b/src/lib/seam/connect/options.ts
@@ -1,4 +1,5 @@
 import type { Client, ClientOptions } from './client.js'
+import { isSeamHttpRequestOption } from './parse-options.js'
 import type { ResolveActionAttemptOptions } from './resolve-action-attempt.js'
 
 export type SeamHttpMultiWorkspaceOptions =
@@ -20,13 +21,6 @@ interface SeamHttpCommonOptions extends ClientOptions, SeamHttpRequestOptions {
 
 export interface SeamHttpRequestOptions {
   waitForActionAttempt?: boolean | ResolveActionAttemptOptions
-}
-
-const isSeamHttpRequestOption = (key: string): boolean => {
-  const keys: Record<keyof SeamHttpRequestOptions, true> = {
-    waitForActionAttempt: true,
-  }
-  return Object.keys(keys).includes(key)
 }
 
 export interface SeamHttpFromPublishableKeyOptions

--- a/src/lib/seam/connect/options.ts
+++ b/src/lib/seam/connect/options.ts
@@ -1,4 +1,5 @@
 import type { Client, ClientOptions } from './client.js'
+import type { ResolveActionAttemptOptions } from './resolve-action-attempt.js'
 
 export type SeamHttpMultiWorkspaceOptions =
   | SeamHttpMultiWorkspaceOptionsWithClient
@@ -13,8 +14,19 @@ export type SeamHttpOptions =
   | SeamHttpOptionsWithConsoleSessionToken
   | SeamHttpOptionsWithPersonalAccessToken
 
-interface SeamHttpCommonOptions extends ClientOptions {
+interface SeamHttpCommonOptions extends ClientOptions, SeamHttpRequestOptions {
   endpoint?: string
+}
+
+export interface SeamHttpRequestOptions {
+  waitForActionAttempt?: boolean | ResolveActionAttemptOptions
+}
+
+const isSeamHttpRequestOption = (key: string): boolean => {
+  const keys: Record<keyof SeamHttpRequestOptions, true> = {
+    waitForActionAttempt: true,
+  }
+  return Object.keys(keys).includes(key)
 }
 
 export interface SeamHttpFromPublishableKeyOptions
@@ -22,7 +34,8 @@ export interface SeamHttpFromPublishableKeyOptions
 
 export interface SeamHttpOptionsFromEnv extends SeamHttpCommonOptions {}
 
-export interface SeamHttpMultiWorkspaceOptionsWithClient {
+export interface SeamHttpMultiWorkspaceOptionsWithClient
+  extends SeamHttpRequestOptions {
   client: Client
 }
 
@@ -31,7 +44,7 @@ export const isSeamHttpMultiWorkspaceOptionsWithClient = (
 ): options is SeamHttpMultiWorkspaceOptionsWithClient =>
   isSeamHttpOptionsWithClient(options)
 
-export interface SeamHttpOptionsWithClient {
+export interface SeamHttpOptionsWithClient extends SeamHttpRequestOptions {
   client: Client
 }
 
@@ -42,7 +55,7 @@ export const isSeamHttpOptionsWithClient = (
   if (options.client == null) return false
 
   const keys = Object.keys(options).filter((k) => k !== 'client')
-  if (keys.length > 0) {
+  if (keys.filter((k) => !isSeamHttpRequestOption(k)).length > 0) {
     throw new SeamHttpInvalidOptionsError(
       `The client option cannot be used with any other option, but received: ${keys.join(
         ', ',

--- a/src/lib/seam/connect/parse-options.ts
+++ b/src/lib/seam/connect/parse-options.ts
@@ -96,3 +96,24 @@ const getEndpointFromEnv = (): string | null | undefined => {
     globalThis.process?.env?.SEAM_API_URL
   )
 }
+
+export const limitToSeamHttpRequestOptions = (
+  options: Required<SeamHttpRequestOptions>,
+): Required<SeamHttpRequestOptions> => {
+  return Object.keys(options)
+    .filter(isSeamHttpRequestOption)
+    .reduce(
+      (obj, key) => ({
+        ...obj,
+        [key]: options[key as keyof SeamHttpRequestOptions],
+      }),
+      {},
+    ) as Required<SeamHttpRequestOptions>
+}
+
+export const isSeamHttpRequestOption = (key: string): boolean => {
+  const keys: Record<keyof SeamHttpRequestOptions, true> = {
+    waitForActionAttempt: true,
+  }
+  return Object.keys(keys).includes(key)
+}

--- a/src/lib/seam/connect/parse-options.ts
+++ b/src/lib/seam/connect/parse-options.ts
@@ -105,13 +105,15 @@ export const limitToSeamHttpRequestOptions = (
     .reduce(
       (obj, key) => ({
         ...obj,
-        [key]: options[key as keyof SeamHttpRequestOptions],
+        [key]: options[key],
       }),
       {},
     ) as Required<SeamHttpRequestOptions>
 }
 
-export const isSeamHttpRequestOption = (key: string): boolean => {
+export const isSeamHttpRequestOption = (
+  key: string,
+): key is keyof SeamHttpRequestOptions => {
   const keys: Record<keyof SeamHttpRequestOptions, true> = {
     waitForActionAttempt: true,
   }

--- a/src/lib/seam/connect/parse-options.ts
+++ b/src/lib/seam/connect/parse-options.ts
@@ -1,7 +1,7 @@
 import version from 'lib/version.js'
 
 import { getAuthHeaders } from './auth.js'
-import type { ClientOptions } from './client.js'
+import type { Client, ClientOptions } from './client.js'
 import {
   isSeamHttpMultiWorkspaceOptionsWithClient,
   isSeamHttpOptionsWithClient,
@@ -23,7 +23,7 @@ export type Options =
 
 export const parseOptions = (
   apiKeyOrOptions: string | Options,
-): ClientOptions => {
+): ClientOptions | { client: Client } => {
   const options = getNormalizedOptions(apiKeyOrOptions)
 
   if (isSeamHttpOptionsWithClient(options)) return options

--- a/src/lib/seam/connect/parse-options.ts
+++ b/src/lib/seam/connect/parse-options.ts
@@ -1,6 +1,7 @@
 import version from 'lib/version.js'
 
 import { getAuthHeaders } from './auth.js'
+import type { Client, ClientOptions } from './client.js'
 import {
   isSeamHttpMultiWorkspaceOptionsWithClient,
   isSeamHttpOptionsWithClient,
@@ -21,9 +22,13 @@ export type Options =
   | SeamHttpMultiWorkspaceOptions
   | (SeamHttpOptions & { publishableKey?: string })
 
+type ParsedOptions = Required<
+  (ClientOptions | { client: Client }) & SeamHttpRequestOptions
+>
+
 export const parseOptions = (
   apiKeyOrOptions: string | Options,
-): SeamHttpOptions & Required<SeamHttpRequestOptions> => {
+): ParsedOptions => {
   const options = getNormalizedOptions(apiKeyOrOptions)
 
   if (isSeamHttpOptionsWithClient(options)) return options

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpAccessCodesUnmanaged {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpAccessCodesUnmanaged {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -31,8 +31,8 @@ export class SeamHttpAccessCodesUnmanaged {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAccessCodesUnmanaged {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpAccessCodesUnmanaged {
   ): Promise<SeamHttpAccessCodesUnmanaged> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpAccessCodesUnmanaged } from './access-codes-unmanaged.js'
 import { SeamHttpClientSessions } from './client-sessions.js'
@@ -34,11 +37,9 @@ export class SeamHttpAccessCodes {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -85,7 +86,9 @@ export class SeamHttpAccessCodes {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -32,8 +32,8 @@ export class SeamHttpAccessCodes {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -30,10 +31,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAccessCodes {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -79,6 +84,9 @@ export class SeamHttpAccessCodes {
   ): Promise<SeamHttpAccessCodes> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({
@@ -122,7 +130,7 @@ export class SeamHttpAccessCodes {
   }
 
   get unmanaged(): SeamHttpAccessCodesUnmanaged {
-    return SeamHttpAccessCodesUnmanaged.fromClient(this.client)
+    return SeamHttpAccessCodesUnmanaged.fromClient(this.client, this.defaults)
   }
 
   async create(

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpAcsAccessGroups {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpAcsAccessGroups {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAcsAccessGroups {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpAcsAccessGroups {
   ): Promise<SeamHttpAcsAccessGroups> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -31,8 +31,8 @@ export class SeamHttpAcsAccessGroups {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAcsCredentials {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpAcsCredentials {
   ): Promise<SeamHttpAcsCredentials> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpAcsCredentials {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpAcsCredentials {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -31,8 +31,8 @@ export class SeamHttpAcsCredentials {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpAcsSystems {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpAcsSystems {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -31,8 +31,8 @@ export class SeamHttpAcsSystems {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAcsSystems {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpAcsSystems {
   ): Promise<SeamHttpAcsSystems> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -31,8 +31,8 @@ export class SeamHttpAcsUsers {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpAcsUsers {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpAcsUsers {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpAcsUsers {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpAcsUsers {
   ): Promise<SeamHttpAcsUsers> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -21,7 +21,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpAcsAccessGroups } from './acs-access-groups.js'
 import { SeamHttpAcsCredentials } from './acs-credentials.js'
@@ -34,11 +37,9 @@ export class SeamHttpAcs {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -85,7 +86,9 @@ export class SeamHttpAcs {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/acs.ts
+++ b/src/lib/seam/connect/routes/acs.ts
@@ -32,8 +32,8 @@ export class SeamHttpAcs {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -35,8 +35,8 @@ export class SeamHttpActionAttempts {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 import { resolveActionAttempt } from 'lib/seam/connect/resolve-action-attempt.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
@@ -34,11 +37,9 @@ export class SeamHttpActionAttempts {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -85,7 +86,9 @@ export class SeamHttpActionAttempts {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -29,8 +29,8 @@ export class SeamHttpClientSessions {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -24,18 +24,19 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 export class SeamHttpClientSessions {
   client: Client
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -82,7 +83,9 @@ export class SeamHttpClientSessions {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -22,15 +22,20 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
 export class SeamHttpClientSessions {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -76,6 +81,9 @@ export class SeamHttpClientSessions {
   ): Promise<SeamHttpClientSessions> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -28,7 +28,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -37,11 +40,9 @@ export class SeamHttpConnectWebviews {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -88,7 +89,9 @@ export class SeamHttpConnectWebviews {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -35,8 +35,8 @@ export class SeamHttpConnectWebviews {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -26,6 +26,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -33,10 +34,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpConnectWebviews {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -82,6 +87,9 @@ export class SeamHttpConnectWebviews {
   ): Promise<SeamHttpConnectWebviews> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -26,6 +26,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -33,10 +34,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpConnectedAccounts {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -82,6 +87,9 @@ export class SeamHttpConnectedAccounts {
   ): Promise<SeamHttpConnectedAccounts> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -28,7 +28,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -37,11 +40,9 @@ export class SeamHttpConnectedAccounts {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -88,7 +89,9 @@ export class SeamHttpConnectedAccounts {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -35,8 +35,8 @@ export class SeamHttpConnectedAccounts {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -31,8 +31,8 @@ export class SeamHttpDevicesUnmanaged {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpDevicesUnmanaged {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpDevicesUnmanaged {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpDevicesUnmanaged {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpDevicesUnmanaged {
   ): Promise<SeamHttpDevicesUnmanaged> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -32,8 +32,8 @@ export class SeamHttpDevices {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpDevicesUnmanaged } from './devices-unmanaged.js'
@@ -34,11 +37,9 @@ export class SeamHttpDevices {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -85,7 +86,9 @@ export class SeamHttpDevices {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -31,8 +31,8 @@ export class SeamHttpEvents {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpEvents {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpEvents {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpEvents {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpEvents {
   ): Promise<SeamHttpEvents> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -36,8 +36,8 @@ export class SeamHttpLocks {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 import { resolveActionAttempt } from 'lib/seam/connect/resolve-action-attempt.js'
 
 import { SeamHttpActionAttempts } from './action-attempts.js'
@@ -35,11 +38,9 @@ export class SeamHttpLocks {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -86,7 +87,9 @@ export class SeamHttpLocks {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -31,8 +31,8 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpNoiseSensorsNoiseThresholds {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   ): Promise<SeamHttpNoiseSensorsNoiseThresholds> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -19,6 +19,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -27,10 +28,14 @@ import { SeamHttpNoiseSensorsNoiseThresholds } from './noise-sensors-noise-thres
 
 export class SeamHttpNoiseSensors {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -76,6 +81,9 @@ export class SeamHttpNoiseSensors {
   ): Promise<SeamHttpNoiseSensors> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({
@@ -119,6 +127,9 @@ export class SeamHttpNoiseSensors {
   }
 
   get noiseThresholds(): SeamHttpNoiseSensorsNoiseThresholds {
-    return SeamHttpNoiseSensorsNoiseThresholds.fromClient(this.client)
+    return SeamHttpNoiseSensorsNoiseThresholds.fromClient(
+      this.client,
+      this.defaults,
+    )
   }
 }

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -29,8 +29,8 @@ export class SeamHttpNoiseSensors {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -21,7 +21,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpNoiseSensorsNoiseThresholds } from './noise-sensors-noise-thresholds.js'
@@ -31,11 +34,9 @@ export class SeamHttpNoiseSensors {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -82,7 +83,9 @@ export class SeamHttpNoiseSensors {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -31,8 +31,8 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpThermostatsClimateSettingSchedules {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   ): Promise<SeamHttpThermostatsClimateSettingSchedules> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -32,8 +32,8 @@ export class SeamHttpThermostats {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpThermostatsClimateSettingSchedules } from './thermostats-climate-setting-schedules.js'
@@ -34,11 +37,9 @@ export class SeamHttpThermostats {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -85,7 +86,9 @@ export class SeamHttpThermostats {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -30,10 +31,14 @@ import { SeamHttpThermostatsClimateSettingSchedules } from './thermostats-climat
 
 export class SeamHttpThermostats {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -79,6 +84,9 @@ export class SeamHttpThermostats {
   ): Promise<SeamHttpThermostats> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({
@@ -122,7 +130,10 @@ export class SeamHttpThermostats {
   }
 
   get climateSettingSchedules(): SeamHttpThermostatsClimateSettingSchedules {
-    return SeamHttpThermostatsClimateSettingSchedules.fromClient(this.client)
+    return SeamHttpThermostatsClimateSettingSchedules.fromClient(
+      this.client,
+      this.defaults,
+    )
   }
 
   async cool(body?: ThermostatsCoolBody): Promise<void> {

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -31,8 +31,8 @@ export class SeamHttpUserIdentities {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -24,7 +24,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -33,11 +36,9 @@ export class SeamHttpUserIdentities {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -84,7 +85,9 @@ export class SeamHttpUserIdentities {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -22,6 +22,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -29,10 +30,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpUserIdentities {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -78,6 +83,9 @@ export class SeamHttpUserIdentities {
   ): Promise<SeamHttpUserIdentities> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -26,6 +26,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -33,10 +34,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpWebhooks {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -82,6 +87,9 @@ export class SeamHttpWebhooks {
   ): Promise<SeamHttpWebhooks> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -35,8 +35,8 @@ export class SeamHttpWebhooks {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -28,7 +28,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -37,11 +40,9 @@ export class SeamHttpWebhooks {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -88,7 +89,9 @@ export class SeamHttpWebhooks {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -28,7 +28,10 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
-import { parseOptions } from 'lib/seam/connect/parse-options.js'
+import {
+  limitToSeamHttpRequestOptions,
+  parseOptions,
+} from 'lib/seam/connect/parse-options.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -37,11 +40,9 @@ export class SeamHttpWorkspaces {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(
@@ -88,7 +89,9 @@ export class SeamHttpWorkspaces {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -35,8 +35,8 @@ export class SeamHttpWorkspaces {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -26,6 +26,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from 'lib/seam/connect/options.js'
 import { parseOptions } from 'lib/seam/connect/parse-options.js'
 
@@ -33,10 +34,14 @@ import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpWorkspaces {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -82,6 +87,9 @@ export class SeamHttpWorkspaces {
   ): Promise<SeamHttpWorkspaces> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/seam-http-multi-workspace.ts
+++ b/src/lib/seam/connect/seam-http-multi-workspace.ts
@@ -16,8 +16,8 @@ export class SeamHttpMultiWorkspace {
   client: Client
 
   constructor(options: SeamHttpMultiWorkspaceOptions) {
-    const clientOptions = parseOptions(options)
-    this.client = createClient(clientOptions)
+    const opts = parseOptions(options)
+    this.client = 'client' in opts ? opts.client : createClient(opts)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/seam-http-multi-workspace.ts
+++ b/src/lib/seam/connect/seam-http-multi-workspace.ts
@@ -10,7 +10,7 @@ import {
   type SeamHttpMultiWorkspaceOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from './options.js'
-import { parseOptions } from './parse-options.js'
+import { limitToSeamHttpRequestOptions, parseOptions } from './parse-options.js'
 import { SeamHttpWorkspaces } from './routes/index.js'
 
 export class SeamHttpMultiWorkspace {
@@ -18,11 +18,9 @@ export class SeamHttpMultiWorkspace {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(options: SeamHttpMultiWorkspaceOptions) {
-    const { waitForActionAttempt, ...opts } = parseOptions(options)
+    const opts = parseOptions(options)
     this.client = 'client' in opts ? opts.client : createClient(opts)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(opts)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/seam-http-multi-workspace.ts
+++ b/src/lib/seam/connect/seam-http-multi-workspace.ts
@@ -8,16 +8,21 @@ import {
   type SeamHttpMultiWorkspaceOptionsWithClient,
   type SeamHttpMultiWorkspaceOptionsWithConsoleSessionToken,
   type SeamHttpMultiWorkspaceOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from './options.js'
 import { parseOptions } from './parse-options.js'
 import { SeamHttpWorkspaces } from './routes/index.js'
 
 export class SeamHttpMultiWorkspace {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(options: SeamHttpMultiWorkspaceOptions) {
-    const opts = parseOptions(options)
+    const { waitForActionAttempt, ...opts } = parseOptions(options)
     this.client = 'client' in opts ? opts.client : createClient(opts)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -72,6 +77,6 @@ export class SeamHttpMultiWorkspace {
   }
 
   get workspaces(): SeamHttpWorkspaces {
-    return SeamHttpWorkspaces.fromClient(this.client)
+    return SeamHttpWorkspaces.fromClient(this.client, this.defaults)
   }
 }

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -90,7 +90,9 @@ export class SeamHttp {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
     if (isSeamHttpOptionsWithClient(clientOptions)) {
-      throw new Error('Cannot pass a client when using fromPublishableKey')
+      throw new SeamHttpInvalidOptionsError(
+        'The client option cannot be used with SeamHttp.fromPublishableKey',
+      )
     }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -16,7 +16,7 @@ import {
   type SeamHttpOptionsWithPersonalAccessToken,
   type SeamHttpRequestOptions,
 } from './options.js'
-import { parseOptions } from './parse-options.js'
+import { limitToSeamHttpRequestOptions, parseOptions } from './parse-options.js'
 import {
   SeamHttpAccessCodes,
   SeamHttpAcs,
@@ -39,11 +39,9 @@ export class SeamHttp {
   readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
+    const options = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
-    this.defaults = {
-      waitForActionAttempt,
-    }
+    this.defaults = limitToSeamHttpRequestOptions(options)
   }
 
   static fromClient(

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -37,8 +37,8 @@ export class SeamHttp {
   client: Client
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const clientOptions = parseOptions(apiKeyOrOptions)
-    this.client = createClient(clientOptions)
+    const options = parseOptions(apiKeyOrOptions)
+    this.client = 'client' in options ? options.client : createClient(options)
   }
 
   static fromClient(
@@ -84,6 +84,9 @@ export class SeamHttp {
   ): Promise<SeamHttp> {
     warnOnInsecureuserIdentifierKey(userIdentifierKey)
     const clientOptions = parseOptions({ ...options, publishableKey })
+    if (isSeamHttpOptionsWithClient(clientOptions)) {
+      throw new Error('Cannot pass a client when using fromPublishableKey')
+    }
     const client = createClient(clientOptions)
     const clientSessions = SeamHttpClientSessions.fromClient(client)
     const { token } = await clientSessions.getOrCreate({

--- a/src/lib/seam/connect/seam-http.ts
+++ b/src/lib/seam/connect/seam-http.ts
@@ -14,6 +14,7 @@ import {
   type SeamHttpOptionsWithClientSessionToken,
   type SeamHttpOptionsWithConsoleSessionToken,
   type SeamHttpOptionsWithPersonalAccessToken,
+  type SeamHttpRequestOptions,
 } from './options.js'
 import { parseOptions } from './parse-options.js'
 import {
@@ -35,10 +36,14 @@ import {
 
 export class SeamHttp {
   client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
 
   constructor(apiKeyOrOptions: string | SeamHttpOptions = {}) {
-    const options = parseOptions(apiKeyOrOptions)
+    const { waitForActionAttempt, ...options } = parseOptions(apiKeyOrOptions)
     this.client = 'client' in options ? options.client : createClient(options)
+    this.defaults = {
+      waitForActionAttempt,
+    }
   }
 
   static fromClient(
@@ -130,58 +135,58 @@ export class SeamHttp {
   }
 
   get accessCodes(): SeamHttpAccessCodes {
-    return SeamHttpAccessCodes.fromClient(this.client)
+    return SeamHttpAccessCodes.fromClient(this.client, this.defaults)
   }
 
   get acs(): SeamHttpAcs {
-    return SeamHttpAcs.fromClient(this.client)
+    return SeamHttpAcs.fromClient(this.client, this.defaults)
   }
 
   get actionAttempts(): SeamHttpActionAttempts {
-    return SeamHttpActionAttempts.fromClient(this.client)
+    return SeamHttpActionAttempts.fromClient(this.client, this.defaults)
   }
 
   get clientSessions(): SeamHttpClientSessions {
-    return SeamHttpClientSessions.fromClient(this.client)
+    return SeamHttpClientSessions.fromClient(this.client, this.defaults)
   }
 
   get connectedAccounts(): SeamHttpConnectedAccounts {
-    return SeamHttpConnectedAccounts.fromClient(this.client)
+    return SeamHttpConnectedAccounts.fromClient(this.client, this.defaults)
   }
 
   get connectWebviews(): SeamHttpConnectWebviews {
-    return SeamHttpConnectWebviews.fromClient(this.client)
+    return SeamHttpConnectWebviews.fromClient(this.client, this.defaults)
   }
 
   get devices(): SeamHttpDevices {
-    return SeamHttpDevices.fromClient(this.client)
+    return SeamHttpDevices.fromClient(this.client, this.defaults)
   }
 
   get events(): SeamHttpEvents {
-    return SeamHttpEvents.fromClient(this.client)
+    return SeamHttpEvents.fromClient(this.client, this.defaults)
   }
 
   get locks(): SeamHttpLocks {
-    return SeamHttpLocks.fromClient(this.client)
+    return SeamHttpLocks.fromClient(this.client, this.defaults)
   }
 
   get noiseSensors(): SeamHttpNoiseSensors {
-    return SeamHttpNoiseSensors.fromClient(this.client)
+    return SeamHttpNoiseSensors.fromClient(this.client, this.defaults)
   }
 
   get thermostats(): SeamHttpThermostats {
-    return SeamHttpThermostats.fromClient(this.client)
+    return SeamHttpThermostats.fromClient(this.client, this.defaults)
   }
 
   get userIdentities(): SeamHttpUserIdentities {
-    return SeamHttpUserIdentities.fromClient(this.client)
+    return SeamHttpUserIdentities.fromClient(this.client, this.defaults)
   }
 
   get webhooks(): SeamHttpWebhooks {
-    return SeamHttpWebhooks.fromClient(this.client)
+    return SeamHttpWebhooks.fromClient(this.client, this.defaults)
   }
 
   get workspaces(): SeamHttpWorkspaces {
-    return SeamHttpWorkspaces.fromClient(this.client)
+    return SeamHttpWorkspaces.fromClient(this.client, this.defaults)
   }
 }

--- a/test/seam/connect/wait-for-action-attempt.test.ts
+++ b/test/seam/connect/wait-for-action-attempt.test.ts
@@ -211,3 +211,49 @@ test('waitForActionAttempt: waits directly on returned action attempt', async (t
 
   t.is(actionAttempt.status, 'success')
 })
+
+test('waitForActionAttempt: does not wait by default', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+  })
+
+  const actionAttempt = await seam.locks.unlockDoor({
+    device_id: seed.august_device_1,
+  })
+
+  t.is(actionAttempt.status, 'pending')
+})
+
+test('waitForActionAttempt: can set class default', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    waitForActionAttempt: true,
+  })
+
+  const actionAttempt = await seam.locks.unlockDoor({
+    device_id: seed.august_device_1,
+  })
+
+  t.is(actionAttempt.status, 'success')
+})
+
+test('waitForActionAttempt: can set class default with object', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    waitForActionAttempt: {
+      timeout: 5000,
+    },
+  })
+
+  const actionAttempt = await seam.locks.unlockDoor({
+    device_id: seed.august_device_1,
+  })
+
+  t.is(actionAttempt.status, 'success')
+})


### PR DESCRIPTION
- Remove client from ClientOptions
- feat: Allow setting waitForActionAttempt as client option
