### PR TITLE
fix: missing types without @seamapi/types installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
+        "@seamapi/types": "^1.44.1",
         "axios": "^1.5.0",
         "axios-better-stacktrace": "^2.1.5",
         "axios-retry": "^3.8.1"
       },
       "devDependencies": {
         "@seamapi/fake-seam-connect": "^1.43.0",
-        "@seamapi/types": "^1.44.1",
         "@types/eslint": "^8.44.2",
         "@types/node": "^18.11.18",
         "ava": "^5.0.1",
@@ -802,7 +802,6 @@
       "version": "1.44.1",
       "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.44.1.tgz",
       "integrity": "sha512-3nio7p4R1SHdfD+GXim62/yU8wZuRJCXJRtl2SaJ/j8vqYLPnV59+QlAA22kAiZ83Ej05CvozZ0fAsrQFkRsrw==",
-      "dev": true,
       "engines": {
         "node": ">=16.13.0",
         "npm": ">= 8.1.0"
@@ -6965,7 +6964,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.6.0.tgz",
       "integrity": "sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=16"
       },
@@ -7518,7 +7517,6 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -98,11 +98,11 @@
   "dependencies": {
     "axios": "^1.5.0",
     "axios-better-stacktrace": "^2.1.5",
-    "axios-retry": "^3.8.1"
+    "axios-retry": "^3.8.1",
+    "@seamapi/types": "^1.44.1"
   },
   "devDependencies": {
     "@seamapi/fake-seam-connect": "^1.43.0",
-    "@seamapi/types": "^1.44.1",
     "@types/eslint": "^8.44.2",
     "@types/node": "^18.11.18",
     "ava": "^5.0.1",


### PR DESCRIPTION
Console was missing types because it didn't have `@seamapi/types` installed, and yarn apparently doesn't install peer dependencies. 🤷‍♂️ 