### PR TITLE
Add SeamHttpRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,16 +394,34 @@ const devices = await seam.client.get<DevicesListResponse>('/devices/list')
 An Axios compatible client may be provided to create a `SeamHttp` instance.
 This API is used internally and is not directly supported.
 
+#### Inspecting the Request
+
+It is possible to inspect a request before it is sent. All of the client methods return an instance of `SeamHttpRequest` which has `url`, `method` and `data` properties. The request is only sent to the server when the `SeamHttpRequest` is awaited.
+
+```ts
+const seam = new SeamHttp('your-api-key')
+
+const request = seam.devices.list()
+
+console.log('Sending request', request.url, request.method, request.data)
+
+const devices = await request // or `await request.execute()` if you prefer
+
+console.log(devices)
+```
+
 ## Development and Testing
 
 ### Quickstart
 
 ```
+
 $ git clone https://github.com/seamapi/javascript-http.git
 $ cd javascript-http
 $ nvm install
 $ npm install
 $ npm run test:watch
+
 ```
 
 Primary development tasks are defined under `scripts` in `package.json`
@@ -411,7 +429,9 @@ and available via `npm run`.
 View them with
 
 ```
+
 $ npm run
+
 ```
 
 ### Source code
@@ -420,7 +440,9 @@ The [source code] is hosted on GitHub.
 Clone the project with
 
 ```
+
 $ git clone git@github.com:seamapi/javascript-http.git
+
 ```
 
 [source code]: https://github.com/seamapi/javascript-http
@@ -433,19 +455,25 @@ Be sure that all commands run under the correct Node version, e.g.,
 if using [nvm], install the correct version with
 
 ```
+
 $ nvm install
+
 ```
 
 Set the active version for each shell session with
 
 ```
+
 $ nvm use
+
 ```
 
 Install the development dependencies with
 
 ```
+
 $ npm install
+
 ```
 
 [Node.js]: https://nodejs.org/
@@ -471,7 +499,9 @@ The `version` input will be passed as the first argument to [npm-version].
 This may be done on the web or using the [GitHub CLI] with
 
 ```
+
 $ gh workflow run version.yml --raw-field version=<version>
+
 ```
 
 [GitHub CLI]: https://cli.github.com/
@@ -528,3 +558,7 @@ loss of use, data, or profits; or business interruption) however caused and on
 any theory of liability, whether in contract, strict liability, or tort
 (including negligence or otherwise) arising in any way out of the use of this
 software, even if advised of the possibility of such damage.
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -396,18 +396,17 @@ This API is used internally and is not directly supported.
 
 #### Inspecting the Request
 
-It is possible to inspect a request before it is sent. All of the client methods return an instance of `SeamHttpRequest` which has `url`, `method` and `body` properties. The request is only sent to the server when the `SeamHttpRequest` is awaited.
+All client methods return an instance of `SeamHttpRequest`.
+Inspect the request before it is sent to the server by intentionally not awaiting the `SeamHttpRequest`;
 
 ```ts
 const seam = new SeamHttp('your-api-key')
 
 const request = seam.devices.list()
 
-console.log('Sending request', request.url, request.method, request.body)
+console.log(`${request.method} ${request.url}`, JSON.stringify(request.body))
 
-const devices = await request // or `await request.execute()` if you prefer
-
-console.log(devices)
+const devices = await request.execute()
 ```
 
 ## Development and Testing

--- a/README.md
+++ b/README.md
@@ -415,13 +415,11 @@ console.log(devices)
 ### Quickstart
 
 ```
-
 $ git clone https://github.com/seamapi/javascript-http.git
 $ cd javascript-http
 $ nvm install
 $ npm install
 $ npm run test:watch
-
 ```
 
 Primary development tasks are defined under `scripts` in `package.json`
@@ -429,9 +427,7 @@ and available via `npm run`.
 View them with
 
 ```
-
 $ npm run
-
 ```
 
 ### Source code
@@ -440,9 +436,7 @@ The [source code] is hosted on GitHub.
 Clone the project with
 
 ```
-
 $ git clone git@github.com:seamapi/javascript-http.git
-
 ```
 
 [source code]: https://github.com/seamapi/javascript-http
@@ -455,25 +449,19 @@ Be sure that all commands run under the correct Node version, e.g.,
 if using [nvm], install the correct version with
 
 ```
-
 $ nvm install
-
 ```
 
 Set the active version for each shell session with
 
 ```
-
 $ nvm use
-
 ```
 
 Install the development dependencies with
 
 ```
-
 $ npm install
-
 ```
 
 [Node.js]: https://nodejs.org/
@@ -499,9 +487,7 @@ The `version` input will be passed as the first argument to [npm-version].
 This may be done on the web or using the [GitHub CLI] with
 
 ```
-
 $ gh workflow run version.yml --raw-field version=<version>
-
 ```
 
 [GitHub CLI]: https://cli.github.com/
@@ -558,7 +544,3 @@ loss of use, data, or profits; or business interruption) however caused and on
 any theory of liability, whether in contract, strict liability, or tort
 (including negligence or otherwise) arising in any way out of the use of this
 software, even if advised of the possibility of such damage.
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -396,14 +396,14 @@ This API is used internally and is not directly supported.
 
 #### Inspecting the Request
 
-It is possible to inspect a request before it is sent. All of the client methods return an instance of `SeamHttpRequest` which has `url`, `method` and `data` properties. The request is only sent to the server when the `SeamHttpRequest` is awaited.
+It is possible to inspect a request before it is sent. All of the client methods return an instance of `SeamHttpRequest` which has `url`, `method` and `body` properties. The request is only sent to the server when the `SeamHttpRequest` is awaited.
 
 ```ts
 const seam = new SeamHttp('your-api-key')
 
 const request = seam.devices.list()
 
-console.log('Sending request', request.url, request.method, request.data)
+console.log('Sending request', request.url, request.method, request.body)
 
 const devices = await request // or `await request.execute()` if you prefer
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -295,7 +295,7 @@ import {
 import {
   resolveActionAttempt,
 } from 'lib/seam/connect/resolve-action-attempt.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 ${
   namespace === 'client_sessions'
@@ -361,7 +361,7 @@ const renderClassMethod = ({
       namespace,
     })},
     ${renderClassMethodOptions({ resource })}
-  ): SeamApiRequest<${isRequestParamOptional ? 'undefined | ' : ''}${renderRequestType(
+  ): SeamHttpRequest<${isRequestParamOptional ? 'undefined | ' : ''}${renderRequestType(
     {
       name,
       namespace,
@@ -371,7 +371,7 @@ const renderClassMethod = ({
       ? 'void, undefined'
       : `${renderResponseType({ name, namespace })}, '${resource}'`
   }> {
-    return new SeamApiRequest(this, {
+    return new SeamHttpRequest(this, {
       url: '${path}',
       method: '${snakeCase(method)}', ${
         requestFormat === 'params' ? 'params,' : ''

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -374,8 +374,8 @@ const renderClassMethod = ({
     return new SeamHttpRequest(this, {
       path: '${path}',
       method: '${snakeCase(method)}', ${
-        requestFormat === 'params' ? 'query: params,' : ''
-      } ${requestFormat === 'body' ? 'body: body,' : ''}
+        requestFormat === 'params' ? 'params,' : ''
+      } ${requestFormat === 'body' ? 'body,' : ''}
       responseKey: ${resource === null ? 'undefined' : `'${resource}'`},
       ${resource === 'action_attempt' ? 'options' : ''}
     })

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -375,8 +375,10 @@ const renderClassMethod = ({
       url: '${path}',
       method: '${snakeCase(method)}', ${
         requestFormat === 'params' ? 'params,' : ''
-      } ${requestFormat === 'body' ? 'data: body,' : ''}
-    }, ${resource === null ? 'undefined' : `'${resource}'`}${resource === 'action_attempt' ? ', options' : ''})
+      } ${requestFormat === 'body' ? 'data: body,' : ''},
+      responseKey: ${resource === null ? 'undefined' : `'${resource}'`},
+      ${resource === 'action_attempt' ? 'options' : ''}
+    })
   }
   `
 

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -361,12 +361,7 @@ const renderClassMethod = ({
       namespace,
     })},
     ${renderClassMethodOptions({ resource })}
-  ): SeamHttpRequest<${isRequestParamOptional ? 'undefined | ' : ''}${renderRequestType(
-    {
-      name,
-      namespace,
-    },
-  )}, ${
+  ): SeamHttpRequest<${
     resource === null
       ? 'void, undefined'
       : `${renderResponseType({ name, namespace })}, '${resource}'`

--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -372,10 +372,10 @@ const renderClassMethod = ({
       : `${renderResponseType({ name, namespace })}, '${resource}'`
   }> {
     return new SeamHttpRequest(this, {
-      url: '${path}',
+      path: '${path}',
       method: '${snakeCase(method)}', ${
-        requestFormat === 'params' ? 'params,' : ''
-      } ${requestFormat === 'body' ? 'data: body,' : ''},
+        requestFormat === 'params' ? 'query: params,' : ''
+      } ${requestFormat === 'body' ? 'body: body,' : ''}
       responseKey: ${resource === null ? 'undefined' : `'${resource}'`},
       ${resource === 'action_attempt' ? 'options' : ''}
     })

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpAccessCodesUnmanaged {
 
   convertToManaged(
     body?: AccessCodesUnmanagedConvertToManagedBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesUnmanagedConvertToManagedBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/unmanaged/convert_to_managed',
@@ -174,12 +174,12 @@ export class SeamHttpAccessCodesUnmanaged {
 
   delete(
     body?: AccessCodesUnmanagedDeleteBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesUnmanagedDeleteBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/unmanaged/delete',
@@ -192,12 +192,12 @@ export class SeamHttpAccessCodesUnmanaged {
 
   get(
     body?: AccessCodesUnmanagedGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesUnmanagedGetParams,
     AccessCodesUnmanagedGetResponse,
     'access_code'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/unmanaged/get',
@@ -210,12 +210,12 @@ export class SeamHttpAccessCodesUnmanaged {
 
   list(
     body?: AccessCodesUnmanagedListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesUnmanagedListParams,
     AccessCodesUnmanagedListResponse,
     'access_codes'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/unmanaged/list',
@@ -228,12 +228,12 @@ export class SeamHttpAccessCodesUnmanaged {
 
   update(
     body?: AccessCodesUnmanagedUpdateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesUnmanagedUpdateBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/unmanaged/update',

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -161,15 +161,12 @@ export class SeamHttpAccessCodesUnmanaged {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/unmanaged/convert_to_managed',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/unmanaged/convert_to_managed',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   delete(
@@ -179,15 +176,12 @@ export class SeamHttpAccessCodesUnmanaged {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/unmanaged/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/unmanaged/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -197,15 +191,12 @@ export class SeamHttpAccessCodesUnmanaged {
     AccessCodesUnmanagedGetResponse,
     'access_code'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/unmanaged/get',
-        method: 'post',
-        data: body,
-      },
-      'access_code',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/unmanaged/get',
+      method: 'post',
+      body,
+      responseKey: 'access_code',
+    })
   }
 
   list(
@@ -215,15 +206,12 @@ export class SeamHttpAccessCodesUnmanaged {
     AccessCodesUnmanagedListResponse,
     'access_codes'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/unmanaged/list',
-        method: 'post',
-        data: body,
-      },
-      'access_codes',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/unmanaged/list',
+      method: 'post',
+      body,
+      responseKey: 'access_codes',
+    })
   }
 
   update(
@@ -233,15 +221,12 @@ export class SeamHttpAccessCodesUnmanaged {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/unmanaged/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/unmanaged/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -156,11 +156,7 @@ export class SeamHttpAccessCodesUnmanaged {
 
   convertToManaged(
     body?: AccessCodesUnmanagedConvertToManagedBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesUnmanagedConvertToManagedBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/unmanaged/convert_to_managed',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpAccessCodesUnmanaged {
 
   delete(
     body?: AccessCodesUnmanagedDeleteBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesUnmanagedDeleteBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/unmanaged/delete',
       method: 'post',
@@ -186,11 +178,7 @@ export class SeamHttpAccessCodesUnmanaged {
 
   get(
     body?: AccessCodesUnmanagedGetParams,
-  ): SeamHttpRequest<
-    undefined | AccessCodesUnmanagedGetParams,
-    AccessCodesUnmanagedGetResponse,
-    'access_code'
-  > {
+  ): SeamHttpRequest<AccessCodesUnmanagedGetResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/unmanaged/get',
       method: 'post',
@@ -201,11 +189,7 @@ export class SeamHttpAccessCodesUnmanaged {
 
   list(
     body?: AccessCodesUnmanagedListParams,
-  ): SeamHttpRequest<
-    undefined | AccessCodesUnmanagedListParams,
-    AccessCodesUnmanagedListResponse,
-    'access_codes'
-  > {
+  ): SeamHttpRequest<AccessCodesUnmanagedListResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/unmanaged/list',
       method: 'post',
@@ -216,11 +200,7 @@ export class SeamHttpAccessCodesUnmanaged {
 
   update(
     body?: AccessCodesUnmanagedUpdateBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesUnmanagedUpdateBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/unmanaged/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,57 +154,94 @@ export class SeamHttpAccessCodesUnmanaged {
     await clientSessions.get()
   }
 
-  async convertToManaged(
+  convertToManaged(
     body?: AccessCodesUnmanagedConvertToManagedBody,
-  ): Promise<void> {
-    await this.client.request<AccessCodesUnmanagedConvertToManagedResponse>({
-      url: '/access_codes/unmanaged/convert_to_managed',
-      method: 'post',
-      data: body,
-    })
+  ): SeamApiRequest<
+    undefined | AccessCodesUnmanagedConvertToManagedBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/unmanaged/convert_to_managed',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async delete(body?: AccessCodesUnmanagedDeleteBody): Promise<void> {
-    await this.client.request<AccessCodesUnmanagedDeleteResponse>({
-      url: '/access_codes/unmanaged/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: AccessCodesUnmanagedDeleteBody,
+  ): SeamApiRequest<
+    undefined | AccessCodesUnmanagedDeleteBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/unmanaged/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: AccessCodesUnmanagedGetParams,
-  ): Promise<AccessCodesUnmanagedGetResponse['access_code']> {
-    const { data } = await this.client.request<AccessCodesUnmanagedGetResponse>(
+  ): SeamApiRequest<
+    undefined | AccessCodesUnmanagedGetParams,
+    AccessCodesUnmanagedGetResponse,
+    'access_code'
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/access_codes/unmanaged/get',
         method: 'post',
         data: body,
       },
+      'access_code',
     )
-
-    return data.access_code
   }
 
-  async list(
+  list(
     body?: AccessCodesUnmanagedListParams,
-  ): Promise<AccessCodesUnmanagedListResponse['access_codes']> {
-    const { data } =
-      await this.client.request<AccessCodesUnmanagedListResponse>({
+  ): SeamApiRequest<
+    undefined | AccessCodesUnmanagedListParams,
+    AccessCodesUnmanagedListResponse,
+    'access_codes'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/access_codes/unmanaged/list',
         method: 'post',
         data: body,
-      })
-
-    return data.access_codes
+      },
+      'access_codes',
+    )
   }
 
-  async update(body?: AccessCodesUnmanagedUpdateBody): Promise<void> {
-    await this.client.request<AccessCodesUnmanagedUpdateResponse>({
-      url: '/access_codes/unmanaged/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: AccessCodesUnmanagedUpdateBody,
+  ): SeamApiRequest<
+    undefined | AccessCodesUnmanagedUpdateBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/unmanaged/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpAccessCodesUnmanaged } from './access-codes-unmanaged.js'
 import { SeamHttpClientSessions } from './client-sessions.js'
@@ -161,12 +161,12 @@ export class SeamHttpAccessCodes {
 
   create(
     body?: AccessCodesCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesCreateBody,
     AccessCodesCreateResponse,
     'access_code'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/create',
@@ -179,12 +179,12 @@ export class SeamHttpAccessCodes {
 
   createMultiple(
     body?: AccessCodesCreateMultipleBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesCreateMultipleBody,
     AccessCodesCreateMultipleResponse,
     'access_codes'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/create_multiple',
@@ -197,8 +197,8 @@ export class SeamHttpAccessCodes {
 
   delete(
     body?: AccessCodesDeleteBody,
-  ): SeamApiRequest<undefined | AccessCodesDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AccessCodesDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/delete',
@@ -211,12 +211,12 @@ export class SeamHttpAccessCodes {
 
   generateCode(
     body?: AccessCodesGenerateCodeBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesGenerateCodeBody,
     AccessCodesGenerateCodeResponse,
     'generated_code'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/generate_code',
@@ -229,12 +229,12 @@ export class SeamHttpAccessCodes {
 
   get(
     body?: AccessCodesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesGetParams,
     AccessCodesGetResponse,
     'access_code'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/get',
@@ -247,12 +247,12 @@ export class SeamHttpAccessCodes {
 
   list(
     body?: AccessCodesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesListParams,
     AccessCodesListResponse,
     'access_codes'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/list',
@@ -265,12 +265,12 @@ export class SeamHttpAccessCodes {
 
   pullBackupAccessCode(
     body?: AccessCodesPullBackupAccessCodeBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AccessCodesPullBackupAccessCodeBody,
     AccessCodesPullBackupAccessCodeResponse,
     'backup_access_code'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/pull_backup_access_code',
@@ -283,8 +283,8 @@ export class SeamHttpAccessCodes {
 
   update(
     body?: AccessCodesUpdateBody,
-  ): SeamApiRequest<undefined | AccessCodesUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AccessCodesUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/access_codes/update',

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpAccessCodesUnmanaged } from './access-codes-unmanaged.js'
 import { SeamHttpClientSessions } from './client-sessions.js'
@@ -158,96 +159,140 @@ export class SeamHttpAccessCodes {
     return SeamHttpAccessCodesUnmanaged.fromClient(this.client, this.defaults)
   }
 
-  async create(
+  create(
     body?: AccessCodesCreateBody,
-  ): Promise<AccessCodesCreateResponse['access_code']> {
-    const { data } = await this.client.request<AccessCodesCreateResponse>({
-      url: '/access_codes/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.access_code
+  ): SeamApiRequest<
+    undefined | AccessCodesCreateBody,
+    AccessCodesCreateResponse,
+    'access_code'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/create',
+        method: 'post',
+        data: body,
+      },
+      'access_code',
+    )
   }
 
-  async createMultiple(
+  createMultiple(
     body?: AccessCodesCreateMultipleBody,
-  ): Promise<AccessCodesCreateMultipleResponse['access_codes']> {
-    const { data } =
-      await this.client.request<AccessCodesCreateMultipleResponse>({
+  ): SeamApiRequest<
+    undefined | AccessCodesCreateMultipleBody,
+    AccessCodesCreateMultipleResponse,
+    'access_codes'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/access_codes/create_multiple',
         method: 'post',
         data: body,
-      })
-
-    return data.access_codes
+      },
+      'access_codes',
+    )
   }
 
-  async delete(body?: AccessCodesDeleteBody): Promise<void> {
-    await this.client.request<AccessCodesDeleteResponse>({
-      url: '/access_codes/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: AccessCodesDeleteBody,
+  ): SeamApiRequest<undefined | AccessCodesDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async generateCode(
+  generateCode(
     body?: AccessCodesGenerateCodeBody,
-  ): Promise<AccessCodesGenerateCodeResponse['generated_code']> {
-    const { data } = await this.client.request<AccessCodesGenerateCodeResponse>(
+  ): SeamApiRequest<
+    undefined | AccessCodesGenerateCodeBody,
+    AccessCodesGenerateCodeResponse,
+    'generated_code'
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/access_codes/generate_code',
         method: 'post',
         data: body,
       },
+      'generated_code',
     )
-
-    return data.generated_code
   }
 
-  async get(
+  get(
     body?: AccessCodesGetParams,
-  ): Promise<AccessCodesGetResponse['access_code']> {
-    const { data } = await this.client.request<AccessCodesGetResponse>({
-      url: '/access_codes/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.access_code
+  ): SeamApiRequest<
+    undefined | AccessCodesGetParams,
+    AccessCodesGetResponse,
+    'access_code'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/get',
+        method: 'post',
+        data: body,
+      },
+      'access_code',
+    )
   }
 
-  async list(
+  list(
     body?: AccessCodesListParams,
-  ): Promise<AccessCodesListResponse['access_codes']> {
-    const { data } = await this.client.request<AccessCodesListResponse>({
-      url: '/access_codes/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.access_codes
+  ): SeamApiRequest<
+    undefined | AccessCodesListParams,
+    AccessCodesListResponse,
+    'access_codes'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/list',
+        method: 'post',
+        data: body,
+      },
+      'access_codes',
+    )
   }
 
-  async pullBackupAccessCode(
+  pullBackupAccessCode(
     body?: AccessCodesPullBackupAccessCodeBody,
-  ): Promise<AccessCodesPullBackupAccessCodeResponse['backup_access_code']> {
-    const { data } =
-      await this.client.request<AccessCodesPullBackupAccessCodeResponse>({
+  ): SeamApiRequest<
+    undefined | AccessCodesPullBackupAccessCodeBody,
+    AccessCodesPullBackupAccessCodeResponse,
+    'backup_access_code'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/access_codes/pull_backup_access_code',
         method: 'post',
         data: body,
-      })
-
-    return data.backup_access_code
+      },
+      'backup_access_code',
+    )
   }
 
-  async update(body?: AccessCodesUpdateBody): Promise<void> {
-    await this.client.request<AccessCodesUpdateResponse>({
-      url: '/access_codes/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: AccessCodesUpdateBody,
+  ): SeamApiRequest<undefined | AccessCodesUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/access_codes/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -161,11 +161,7 @@ export class SeamHttpAccessCodes {
 
   create(
     body?: AccessCodesCreateBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesCreateBody,
-    AccessCodesCreateResponse,
-    'access_code'
-  > {
+  ): SeamHttpRequest<AccessCodesCreateResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/create',
       method: 'post',
@@ -176,11 +172,7 @@ export class SeamHttpAccessCodes {
 
   createMultiple(
     body?: AccessCodesCreateMultipleBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesCreateMultipleBody,
-    AccessCodesCreateMultipleResponse,
-    'access_codes'
-  > {
+  ): SeamHttpRequest<AccessCodesCreateMultipleResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/create_multiple',
       method: 'post',
@@ -189,9 +181,7 @@ export class SeamHttpAccessCodes {
     })
   }
 
-  delete(
-    body?: AccessCodesDeleteBody,
-  ): SeamHttpRequest<undefined | AccessCodesDeleteBody, void, undefined> {
+  delete(body?: AccessCodesDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/delete',
       method: 'post',
@@ -202,11 +192,7 @@ export class SeamHttpAccessCodes {
 
   generateCode(
     body?: AccessCodesGenerateCodeBody,
-  ): SeamHttpRequest<
-    undefined | AccessCodesGenerateCodeBody,
-    AccessCodesGenerateCodeResponse,
-    'generated_code'
-  > {
+  ): SeamHttpRequest<AccessCodesGenerateCodeResponse, 'generated_code'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/generate_code',
       method: 'post',
@@ -217,11 +203,7 @@ export class SeamHttpAccessCodes {
 
   get(
     body?: AccessCodesGetParams,
-  ): SeamHttpRequest<
-    undefined | AccessCodesGetParams,
-    AccessCodesGetResponse,
-    'access_code'
-  > {
+  ): SeamHttpRequest<AccessCodesGetResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/get',
       method: 'post',
@@ -232,11 +214,7 @@ export class SeamHttpAccessCodes {
 
   list(
     body?: AccessCodesListParams,
-  ): SeamHttpRequest<
-    undefined | AccessCodesListParams,
-    AccessCodesListResponse,
-    'access_codes'
-  > {
+  ): SeamHttpRequest<AccessCodesListResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/list',
       method: 'post',
@@ -248,7 +226,6 @@ export class SeamHttpAccessCodes {
   pullBackupAccessCode(
     body?: AccessCodesPullBackupAccessCodeBody,
   ): SeamHttpRequest<
-    undefined | AccessCodesPullBackupAccessCodeBody,
     AccessCodesPullBackupAccessCodeResponse,
     'backup_access_code'
   > {
@@ -260,9 +237,7 @@ export class SeamHttpAccessCodes {
     })
   }
 
-  update(
-    body?: AccessCodesUpdateBody,
-  ): SeamHttpRequest<undefined | AccessCodesUpdateBody, void, undefined> {
+  update(body?: AccessCodesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/access_codes/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -166,15 +166,12 @@ export class SeamHttpAccessCodes {
     AccessCodesCreateResponse,
     'access_code'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/create',
-        method: 'post',
-        data: body,
-      },
-      'access_code',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/create',
+      method: 'post',
+      body,
+      responseKey: 'access_code',
+    })
   }
 
   createMultiple(
@@ -184,29 +181,23 @@ export class SeamHttpAccessCodes {
     AccessCodesCreateMultipleResponse,
     'access_codes'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/create_multiple',
-        method: 'post',
-        data: body,
-      },
-      'access_codes',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/create_multiple',
+      method: 'post',
+      body,
+      responseKey: 'access_codes',
+    })
   }
 
   delete(
     body?: AccessCodesDeleteBody,
   ): SeamHttpRequest<undefined | AccessCodesDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   generateCode(
@@ -216,15 +207,12 @@ export class SeamHttpAccessCodes {
     AccessCodesGenerateCodeResponse,
     'generated_code'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/generate_code',
-        method: 'post',
-        data: body,
-      },
-      'generated_code',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/generate_code',
+      method: 'post',
+      body,
+      responseKey: 'generated_code',
+    })
   }
 
   get(
@@ -234,15 +222,12 @@ export class SeamHttpAccessCodes {
     AccessCodesGetResponse,
     'access_code'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/get',
-        method: 'post',
-        data: body,
-      },
-      'access_code',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/get',
+      method: 'post',
+      body,
+      responseKey: 'access_code',
+    })
   }
 
   list(
@@ -252,15 +237,12 @@ export class SeamHttpAccessCodes {
     AccessCodesListResponse,
     'access_codes'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/list',
-        method: 'post',
-        data: body,
-      },
-      'access_codes',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/list',
+      method: 'post',
+      body,
+      responseKey: 'access_codes',
+    })
   }
 
   pullBackupAccessCode(
@@ -270,29 +252,23 @@ export class SeamHttpAccessCodes {
     AccessCodesPullBackupAccessCodeResponse,
     'backup_access_code'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/pull_backup_access_code',
-        method: 'post',
-        data: body,
-      },
-      'backup_access_code',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/pull_backup_access_code',
+      method: 'post',
+      body,
+      responseKey: 'backup_access_code',
+    })
   }
 
   update(
     body?: AccessCodesUpdateBody,
   ): SeamHttpRequest<undefined | AccessCodesUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/access_codes/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/access_codes/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,57 +154,90 @@ export class SeamHttpAcsAccessGroups {
     await clientSessions.get()
   }
 
-  async addUser(body?: AcsAccessGroupsAddUserBody): Promise<void> {
-    await this.client.request<AcsAccessGroupsAddUserResponse>({
-      url: '/acs/access_groups/add_user',
-      method: 'post',
-      data: body,
-    })
+  addUser(
+    body?: AcsAccessGroupsAddUserBody,
+  ): SeamApiRequest<undefined | AcsAccessGroupsAddUserBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/access_groups/add_user',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: AcsAccessGroupsGetParams,
-  ): Promise<AcsAccessGroupsGetResponse['acs_access_group']> {
-    const { data } = await this.client.request<AcsAccessGroupsGetResponse>({
-      url: '/acs/access_groups/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_access_group
+  ): SeamApiRequest<
+    undefined | AcsAccessGroupsGetParams,
+    AcsAccessGroupsGetResponse,
+    'acs_access_group'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/access_groups/get',
+        method: 'post',
+        data: body,
+      },
+      'acs_access_group',
+    )
   }
 
-  async list(
+  list(
     body?: AcsAccessGroupsListParams,
-  ): Promise<AcsAccessGroupsListResponse['acs_access_groups']> {
-    const { data } = await this.client.request<AcsAccessGroupsListResponse>({
-      url: '/acs/access_groups/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_access_groups
+  ): SeamApiRequest<
+    undefined | AcsAccessGroupsListParams,
+    AcsAccessGroupsListResponse,
+    'acs_access_groups'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/access_groups/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_access_groups',
+    )
   }
 
-  async listUsers(
+  listUsers(
     body?: AcsAccessGroupsListUsersParams,
-  ): Promise<AcsAccessGroupsListUsersResponse['acs_users']> {
-    const { data } =
-      await this.client.request<AcsAccessGroupsListUsersResponse>({
+  ): SeamApiRequest<
+    undefined | AcsAccessGroupsListUsersParams,
+    AcsAccessGroupsListUsersResponse,
+    'acs_users'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/acs/access_groups/list_users',
         method: 'post',
         data: body,
-      })
-
-    return data.acs_users
+      },
+      'acs_users',
+    )
   }
 
-  async removeUser(body?: AcsAccessGroupsRemoveUserBody): Promise<void> {
-    await this.client.request<AcsAccessGroupsRemoveUserResponse>({
-      url: '/acs/access_groups/remove_user',
-      method: 'post',
-      data: body,
-    })
+  removeUser(
+    body?: AcsAccessGroupsRemoveUserBody,
+  ): SeamApiRequest<
+    undefined | AcsAccessGroupsRemoveUserBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/access_groups/remove_user',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -157,15 +157,12 @@ export class SeamHttpAcsAccessGroups {
   addUser(
     body?: AcsAccessGroupsAddUserBody,
   ): SeamHttpRequest<undefined | AcsAccessGroupsAddUserBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/access_groups/add_user',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/access_groups/add_user',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -175,15 +172,12 @@ export class SeamHttpAcsAccessGroups {
     AcsAccessGroupsGetResponse,
     'acs_access_group'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/access_groups/get',
-        method: 'post',
-        data: body,
-      },
-      'acs_access_group',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/access_groups/get',
+      method: 'post',
+      body,
+      responseKey: 'acs_access_group',
+    })
   }
 
   list(
@@ -193,15 +187,12 @@ export class SeamHttpAcsAccessGroups {
     AcsAccessGroupsListResponse,
     'acs_access_groups'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/access_groups/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_access_groups',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/access_groups/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_access_groups',
+    })
   }
 
   listUsers(
@@ -211,15 +202,12 @@ export class SeamHttpAcsAccessGroups {
     AcsAccessGroupsListUsersResponse,
     'acs_users'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/access_groups/list_users',
-        method: 'post',
-        data: body,
-      },
-      'acs_users',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/access_groups/list_users',
+      method: 'post',
+      body,
+      responseKey: 'acs_users',
+    })
   }
 
   removeUser(
@@ -229,15 +217,12 @@ export class SeamHttpAcsAccessGroups {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/access_groups/remove_user',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/access_groups/remove_user',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -154,9 +154,7 @@ export class SeamHttpAcsAccessGroups {
     await clientSessions.get()
   }
 
-  addUser(
-    body?: AcsAccessGroupsAddUserBody,
-  ): SeamHttpRequest<undefined | AcsAccessGroupsAddUserBody, void, undefined> {
+  addUser(body?: AcsAccessGroupsAddUserBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/access_groups/add_user',
       method: 'post',
@@ -167,11 +165,7 @@ export class SeamHttpAcsAccessGroups {
 
   get(
     body?: AcsAccessGroupsGetParams,
-  ): SeamHttpRequest<
-    undefined | AcsAccessGroupsGetParams,
-    AcsAccessGroupsGetResponse,
-    'acs_access_group'
-  > {
+  ): SeamHttpRequest<AcsAccessGroupsGetResponse, 'acs_access_group'> {
     return new SeamHttpRequest(this, {
       path: '/acs/access_groups/get',
       method: 'post',
@@ -182,11 +176,7 @@ export class SeamHttpAcsAccessGroups {
 
   list(
     body?: AcsAccessGroupsListParams,
-  ): SeamHttpRequest<
-    undefined | AcsAccessGroupsListParams,
-    AcsAccessGroupsListResponse,
-    'acs_access_groups'
-  > {
+  ): SeamHttpRequest<AcsAccessGroupsListResponse, 'acs_access_groups'> {
     return new SeamHttpRequest(this, {
       path: '/acs/access_groups/list',
       method: 'post',
@@ -197,11 +187,7 @@ export class SeamHttpAcsAccessGroups {
 
   listUsers(
     body?: AcsAccessGroupsListUsersParams,
-  ): SeamHttpRequest<
-    undefined | AcsAccessGroupsListUsersParams,
-    AcsAccessGroupsListUsersResponse,
-    'acs_users'
-  > {
+  ): SeamHttpRequest<AcsAccessGroupsListUsersResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
       path: '/acs/access_groups/list_users',
       method: 'post',
@@ -212,11 +198,7 @@ export class SeamHttpAcsAccessGroups {
 
   removeUser(
     body?: AcsAccessGroupsRemoveUserBody,
-  ): SeamHttpRequest<
-    undefined | AcsAccessGroupsRemoveUserBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/access_groups/remove_user',
       method: 'post',

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,8 @@ export class SeamHttpAcsAccessGroups {
 
   addUser(
     body?: AcsAccessGroupsAddUserBody,
-  ): SeamApiRequest<undefined | AcsAccessGroupsAddUserBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsAccessGroupsAddUserBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/access_groups/add_user',
@@ -170,12 +170,12 @@ export class SeamHttpAcsAccessGroups {
 
   get(
     body?: AcsAccessGroupsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsAccessGroupsGetParams,
     AcsAccessGroupsGetResponse,
     'acs_access_group'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/access_groups/get',
@@ -188,12 +188,12 @@ export class SeamHttpAcsAccessGroups {
 
   list(
     body?: AcsAccessGroupsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsAccessGroupsListParams,
     AcsAccessGroupsListResponse,
     'acs_access_groups'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/access_groups/list',
@@ -206,12 +206,12 @@ export class SeamHttpAcsAccessGroups {
 
   listUsers(
     body?: AcsAccessGroupsListUsersParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsAccessGroupsListUsersParams,
     AcsAccessGroupsListUsersResponse,
     'acs_users'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/access_groups/list_users',
@@ -224,12 +224,12 @@ export class SeamHttpAcsAccessGroups {
 
   removeUser(
     body?: AcsAccessGroupsRemoveUserBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsAccessGroupsRemoveUserBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/access_groups/remove_user',

--- a/src/lib/seam/connect/routes/acs-credential-pools.ts
+++ b/src/lib/seam/connect/routes/acs-credential-pools.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpAcsCredentialPools {
 
   list(
     body?: AcsCredentialPoolsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialPoolsListParams,
     AcsCredentialPoolsListResponse,
     'acs_credential_pools'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credential_pools/list',

--- a/src/lib/seam/connect/routes/acs-credential-pools.ts
+++ b/src/lib/seam/connect/routes/acs-credential-pools.ts
@@ -156,11 +156,7 @@ export class SeamHttpAcsCredentialPools {
 
   list(
     body?: AcsCredentialPoolsListParams,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialPoolsListParams,
-    AcsCredentialPoolsListResponse,
-    'acs_credential_pools'
-  > {
+  ): SeamHttpRequest<AcsCredentialPoolsListResponse, 'acs_credential_pools'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credential_pools/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/acs-credential-pools.ts
+++ b/src/lib/seam/connect/routes/acs-credential-pools.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,16 +154,22 @@ export class SeamHttpAcsCredentialPools {
     await clientSessions.get()
   }
 
-  async list(
+  list(
     body?: AcsCredentialPoolsListParams,
-  ): Promise<AcsCredentialPoolsListResponse['acs_credential_pools']> {
-    const { data } = await this.client.request<AcsCredentialPoolsListResponse>({
-      url: '/acs/credential_pools/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential_pools
+  ): SeamApiRequest<
+    undefined | AcsCredentialPoolsListParams,
+    AcsCredentialPoolsListResponse,
+    'acs_credential_pools'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credential_pools/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential_pools',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credential-pools.ts
+++ b/src/lib/seam/connect/routes/acs-credential-pools.ts
@@ -161,15 +161,12 @@ export class SeamHttpAcsCredentialPools {
     AcsCredentialPoolsListResponse,
     'acs_credential_pools'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credential_pools/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential_pools',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credential_pools/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential_pools',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
+++ b/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -159,12 +159,12 @@ export class SeamHttpAcsCredentialProvisioningAutomations {
 
   launch(
     body?: AcsCredentialProvisioningAutomationsLaunchBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialProvisioningAutomationsLaunchBody,
     AcsCredentialProvisioningAutomationsLaunchResponse,
     'acs_credential_provisioning_automation'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credential_provisioning_automations/launch',

--- a/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
+++ b/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
@@ -164,15 +164,12 @@ export class SeamHttpAcsCredentialProvisioningAutomations {
     AcsCredentialProvisioningAutomationsLaunchResponse,
     'acs_credential_provisioning_automation'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credential_provisioning_automations/launch',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential_provisioning_automation',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credential_provisioning_automations/launch',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential_provisioning_automation',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
+++ b/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,21 +157,22 @@ export class SeamHttpAcsCredentialProvisioningAutomations {
     await clientSessions.get()
   }
 
-  async launch(
+  launch(
     body?: AcsCredentialProvisioningAutomationsLaunchBody,
-  ): Promise<
-    AcsCredentialProvisioningAutomationsLaunchResponse['acs_credential_provisioning_automation']
+  ): SeamApiRequest<
+    undefined | AcsCredentialProvisioningAutomationsLaunchBody,
+    AcsCredentialProvisioningAutomationsLaunchResponse,
+    'acs_credential_provisioning_automation'
   > {
-    const { data } =
-      await this.client.request<AcsCredentialProvisioningAutomationsLaunchResponse>(
-        {
-          url: '/acs/credential_provisioning_automations/launch',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.acs_credential_provisioning_automation
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credential_provisioning_automations/launch',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential_provisioning_automation',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
+++ b/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
@@ -160,7 +160,6 @@ export class SeamHttpAcsCredentialProvisioningAutomations {
   launch(
     body?: AcsCredentialProvisioningAutomationsLaunchBody,
   ): SeamHttpRequest<
-    undefined | AcsCredentialProvisioningAutomationsLaunchBody,
     AcsCredentialProvisioningAutomationsLaunchResponse,
     'acs_credential_provisioning_automation'
   > {

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -156,11 +156,7 @@ export class SeamHttpAcsCredentials {
 
   assign(
     body?: AcsCredentialsAssignBody,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsAssignBody,
-    AcsCredentialsAssignResponse,
-    'acs_credential'
-  > {
+  ): SeamHttpRequest<AcsCredentialsAssignResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/assign',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpAcsCredentials {
 
   create(
     body?: AcsCredentialsCreateBody,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsCreateBody,
-    AcsCredentialsCreateResponse,
-    'acs_credential'
-  > {
+  ): SeamHttpRequest<AcsCredentialsCreateResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/create',
       method: 'post',
@@ -184,9 +176,7 @@ export class SeamHttpAcsCredentials {
     })
   }
 
-  delete(
-    body?: AcsCredentialsDeleteBody,
-  ): SeamHttpRequest<undefined | AcsCredentialsDeleteBody, void, undefined> {
+  delete(body?: AcsCredentialsDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/delete',
       method: 'post',
@@ -197,11 +187,7 @@ export class SeamHttpAcsCredentials {
 
   get(
     body?: AcsCredentialsGetParams,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsGetParams,
-    AcsCredentialsGetResponse,
-    'acs_credential'
-  > {
+  ): SeamHttpRequest<AcsCredentialsGetResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/get',
       method: 'post',
@@ -212,11 +198,7 @@ export class SeamHttpAcsCredentials {
 
   list(
     body?: AcsCredentialsListParams,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsListParams,
-    AcsCredentialsListResponse,
-    'acs_credentials'
-  > {
+  ): SeamHttpRequest<AcsCredentialsListResponse, 'acs_credentials'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/list',
       method: 'post',
@@ -227,11 +209,7 @@ export class SeamHttpAcsCredentials {
 
   unassign(
     body?: AcsCredentialsUnassignBody,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsUnassignBody,
-    AcsCredentialsUnassignResponse,
-    'acs_credential'
-  > {
+  ): SeamHttpRequest<AcsCredentialsUnassignResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/unassign',
       method: 'post',
@@ -242,11 +220,7 @@ export class SeamHttpAcsCredentials {
 
   update(
     body?: AcsCredentialsUpdateBody,
-  ): SeamHttpRequest<
-    undefined | AcsCredentialsUpdateBody,
-    AcsCredentialsUpdateResponse,
-    'acs_credential'
-  > {
+  ): SeamHttpRequest<AcsCredentialsUpdateResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
       path: '/acs/credentials/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,84 +154,126 @@ export class SeamHttpAcsCredentials {
     await clientSessions.get()
   }
 
-  async assign(
+  assign(
     body?: AcsCredentialsAssignBody,
-  ): Promise<AcsCredentialsAssignResponse['acs_credential']> {
-    const { data } = await this.client.request<AcsCredentialsAssignResponse>({
-      url: '/acs/credentials/assign',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential
+  ): SeamApiRequest<
+    undefined | AcsCredentialsAssignBody,
+    AcsCredentialsAssignResponse,
+    'acs_credential'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/assign',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential',
+    )
   }
 
-  async create(
+  create(
     body?: AcsCredentialsCreateBody,
-  ): Promise<AcsCredentialsCreateResponse['acs_credential']> {
-    const { data } = await this.client.request<AcsCredentialsCreateResponse>({
-      url: '/acs/credentials/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential
+  ): SeamApiRequest<
+    undefined | AcsCredentialsCreateBody,
+    AcsCredentialsCreateResponse,
+    'acs_credential'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/create',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential',
+    )
   }
 
-  async delete(body?: AcsCredentialsDeleteBody): Promise<void> {
-    await this.client.request<AcsCredentialsDeleteResponse>({
-      url: '/acs/credentials/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: AcsCredentialsDeleteBody,
+  ): SeamApiRequest<undefined | AcsCredentialsDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: AcsCredentialsGetParams,
-  ): Promise<AcsCredentialsGetResponse['acs_credential']> {
-    const { data } = await this.client.request<AcsCredentialsGetResponse>({
-      url: '/acs/credentials/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential
+  ): SeamApiRequest<
+    undefined | AcsCredentialsGetParams,
+    AcsCredentialsGetResponse,
+    'acs_credential'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/get',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential',
+    )
   }
 
-  async list(
+  list(
     body?: AcsCredentialsListParams,
-  ): Promise<AcsCredentialsListResponse['acs_credentials']> {
-    const { data } = await this.client.request<AcsCredentialsListResponse>({
-      url: '/acs/credentials/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credentials
+  ): SeamApiRequest<
+    undefined | AcsCredentialsListParams,
+    AcsCredentialsListResponse,
+    'acs_credentials'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_credentials',
+    )
   }
 
-  async unassign(
+  unassign(
     body?: AcsCredentialsUnassignBody,
-  ): Promise<AcsCredentialsUnassignResponse['acs_credential']> {
-    const { data } = await this.client.request<AcsCredentialsUnassignResponse>({
-      url: '/acs/credentials/unassign',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential
+  ): SeamApiRequest<
+    undefined | AcsCredentialsUnassignBody,
+    AcsCredentialsUnassignResponse,
+    'acs_credential'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/unassign',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential',
+    )
   }
 
-  async update(
+  update(
     body?: AcsCredentialsUpdateBody,
-  ): Promise<AcsCredentialsUpdateResponse['acs_credential']> {
-    const { data } = await this.client.request<AcsCredentialsUpdateResponse>({
-      url: '/acs/credentials/update',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_credential
+  ): SeamApiRequest<
+    undefined | AcsCredentialsUpdateBody,
+    AcsCredentialsUpdateResponse,
+    'acs_credential'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/credentials/update',
+        method: 'post',
+        data: body,
+      },
+      'acs_credential',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -161,15 +161,12 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsAssignResponse,
     'acs_credential'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/assign',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/assign',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential',
+    })
   }
 
   create(
@@ -179,29 +176,23 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsCreateResponse,
     'acs_credential'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/create',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/create',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential',
+    })
   }
 
   delete(
     body?: AcsCredentialsDeleteBody,
   ): SeamHttpRequest<undefined | AcsCredentialsDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -211,15 +202,12 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsGetResponse,
     'acs_credential'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/get',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/get',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential',
+    })
   }
 
   list(
@@ -229,15 +217,12 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsListResponse,
     'acs_credentials'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_credentials',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_credentials',
+    })
   }
 
   unassign(
@@ -247,15 +232,12 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsUnassignResponse,
     'acs_credential'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/unassign',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/unassign',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential',
+    })
   }
 
   update(
@@ -265,15 +247,12 @@ export class SeamHttpAcsCredentials {
     AcsCredentialsUpdateResponse,
     'acs_credential'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/credentials/update',
-        method: 'post',
-        data: body,
-      },
-      'acs_credential',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/credentials/update',
+      method: 'post',
+      body,
+      responseKey: 'acs_credential',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpAcsCredentials {
 
   assign(
     body?: AcsCredentialsAssignBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsAssignBody,
     AcsCredentialsAssignResponse,
     'acs_credential'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/assign',
@@ -174,12 +174,12 @@ export class SeamHttpAcsCredentials {
 
   create(
     body?: AcsCredentialsCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsCreateBody,
     AcsCredentialsCreateResponse,
     'acs_credential'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/create',
@@ -192,8 +192,8 @@ export class SeamHttpAcsCredentials {
 
   delete(
     body?: AcsCredentialsDeleteBody,
-  ): SeamApiRequest<undefined | AcsCredentialsDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsCredentialsDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/delete',
@@ -206,12 +206,12 @@ export class SeamHttpAcsCredentials {
 
   get(
     body?: AcsCredentialsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsGetParams,
     AcsCredentialsGetResponse,
     'acs_credential'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/get',
@@ -224,12 +224,12 @@ export class SeamHttpAcsCredentials {
 
   list(
     body?: AcsCredentialsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsListParams,
     AcsCredentialsListResponse,
     'acs_credentials'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/list',
@@ -242,12 +242,12 @@ export class SeamHttpAcsCredentials {
 
   unassign(
     body?: AcsCredentialsUnassignBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsUnassignBody,
     AcsCredentialsUnassignResponse,
     'acs_credential'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/unassign',
@@ -260,12 +260,12 @@ export class SeamHttpAcsCredentials {
 
   update(
     body?: AcsCredentialsUpdateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsCredentialsUpdateBody,
     AcsCredentialsUpdateResponse,
     'acs_credential'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/credentials/update',

--- a/src/lib/seam/connect/routes/acs-entrances.ts
+++ b/src/lib/seam/connect/routes/acs-entrances.ts
@@ -156,11 +156,7 @@ export class SeamHttpAcsEntrances {
 
   get(
     body?: AcsEntrancesGetParams,
-  ): SeamHttpRequest<
-    undefined | AcsEntrancesGetParams,
-    AcsEntrancesGetResponse,
-    'acs_entrance'
-  > {
+  ): SeamHttpRequest<AcsEntrancesGetResponse, 'acs_entrance'> {
     return new SeamHttpRequest(this, {
       path: '/acs/entrances/get',
       method: 'post',
@@ -171,7 +167,7 @@ export class SeamHttpAcsEntrances {
 
   grantAccess(
     body?: AcsEntrancesGrantAccessBody,
-  ): SeamHttpRequest<undefined | AcsEntrancesGrantAccessBody, void, undefined> {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/entrances/grant_access',
       method: 'post',
@@ -182,11 +178,7 @@ export class SeamHttpAcsEntrances {
 
   list(
     body?: AcsEntrancesListParams,
-  ): SeamHttpRequest<
-    undefined | AcsEntrancesListParams,
-    AcsEntrancesListResponse,
-    'acs_entrances'
-  > {
+  ): SeamHttpRequest<AcsEntrancesListResponse, 'acs_entrances'> {
     return new SeamHttpRequest(this, {
       path: '/acs/entrances/list',
       method: 'post',
@@ -198,7 +190,6 @@ export class SeamHttpAcsEntrances {
   listCredentialsWithAccess(
     body?: AcsEntrancesListCredentialsWithAccessParams,
   ): SeamHttpRequest<
-    undefined | AcsEntrancesListCredentialsWithAccessParams,
     AcsEntrancesListCredentialsWithAccessResponse,
     'acs_credentials'
   > {

--- a/src/lib/seam/connect/routes/acs-entrances.ts
+++ b/src/lib/seam/connect/routes/acs-entrances.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpAcsEntrances {
 
   get(
     body?: AcsEntrancesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsEntrancesGetParams,
     AcsEntrancesGetResponse,
     'acs_entrance'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/entrances/get',
@@ -174,8 +174,8 @@ export class SeamHttpAcsEntrances {
 
   grantAccess(
     body?: AcsEntrancesGrantAccessBody,
-  ): SeamApiRequest<undefined | AcsEntrancesGrantAccessBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsEntrancesGrantAccessBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/entrances/grant_access',
@@ -188,12 +188,12 @@ export class SeamHttpAcsEntrances {
 
   list(
     body?: AcsEntrancesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsEntrancesListParams,
     AcsEntrancesListResponse,
     'acs_entrances'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/entrances/list',
@@ -206,12 +206,12 @@ export class SeamHttpAcsEntrances {
 
   listCredentialsWithAccess(
     body?: AcsEntrancesListCredentialsWithAccessParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsEntrancesListCredentialsWithAccessParams,
     AcsEntrancesListCredentialsWithAccessResponse,
     'acs_credentials'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/entrances/list_credentials_with_access',

--- a/src/lib/seam/connect/routes/acs-entrances.ts
+++ b/src/lib/seam/connect/routes/acs-entrances.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,49 +154,72 @@ export class SeamHttpAcsEntrances {
     await clientSessions.get()
   }
 
-  async get(
+  get(
     body?: AcsEntrancesGetParams,
-  ): Promise<AcsEntrancesGetResponse['acs_entrance']> {
-    const { data } = await this.client.request<AcsEntrancesGetResponse>({
-      url: '/acs/entrances/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_entrance
+  ): SeamApiRequest<
+    undefined | AcsEntrancesGetParams,
+    AcsEntrancesGetResponse,
+    'acs_entrance'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/entrances/get',
+        method: 'post',
+        data: body,
+      },
+      'acs_entrance',
+    )
   }
 
-  async grantAccess(body?: AcsEntrancesGrantAccessBody): Promise<void> {
-    await this.client.request<AcsEntrancesGrantAccessResponse>({
-      url: '/acs/entrances/grant_access',
-      method: 'post',
-      data: body,
-    })
+  grantAccess(
+    body?: AcsEntrancesGrantAccessBody,
+  ): SeamApiRequest<undefined | AcsEntrancesGrantAccessBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/entrances/grant_access',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async list(
+  list(
     body?: AcsEntrancesListParams,
-  ): Promise<AcsEntrancesListResponse['acs_entrances']> {
-    const { data } = await this.client.request<AcsEntrancesListResponse>({
-      url: '/acs/entrances/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_entrances
+  ): SeamApiRequest<
+    undefined | AcsEntrancesListParams,
+    AcsEntrancesListResponse,
+    'acs_entrances'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/entrances/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_entrances',
+    )
   }
 
-  async listCredentialsWithAccess(
+  listCredentialsWithAccess(
     body?: AcsEntrancesListCredentialsWithAccessParams,
-  ): Promise<AcsEntrancesListCredentialsWithAccessResponse['acs_credentials']> {
-    const { data } =
-      await this.client.request<AcsEntrancesListCredentialsWithAccessResponse>({
+  ): SeamApiRequest<
+    undefined | AcsEntrancesListCredentialsWithAccessParams,
+    AcsEntrancesListCredentialsWithAccessResponse,
+    'acs_credentials'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/acs/entrances/list_credentials_with_access',
         method: 'post',
         data: body,
-      })
-
-    return data.acs_credentials
+      },
+      'acs_credentials',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-entrances.ts
+++ b/src/lib/seam/connect/routes/acs-entrances.ts
@@ -161,29 +161,23 @@ export class SeamHttpAcsEntrances {
     AcsEntrancesGetResponse,
     'acs_entrance'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/entrances/get',
-        method: 'post',
-        data: body,
-      },
-      'acs_entrance',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/entrances/get',
+      method: 'post',
+      body,
+      responseKey: 'acs_entrance',
+    })
   }
 
   grantAccess(
     body?: AcsEntrancesGrantAccessBody,
   ): SeamHttpRequest<undefined | AcsEntrancesGrantAccessBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/entrances/grant_access',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/entrances/grant_access',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   list(
@@ -193,15 +187,12 @@ export class SeamHttpAcsEntrances {
     AcsEntrancesListResponse,
     'acs_entrances'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/entrances/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_entrances',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/entrances/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_entrances',
+    })
   }
 
   listCredentialsWithAccess(
@@ -211,15 +202,12 @@ export class SeamHttpAcsEntrances {
     AcsEntrancesListCredentialsWithAccessResponse,
     'acs_credentials'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/entrances/list_credentials_with_access',
-        method: 'post',
-        data: body,
-      },
-      'acs_credentials',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/entrances/list_credentials_with_access',
+      method: 'post',
+      body,
+      responseKey: 'acs_credentials',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -161,15 +161,12 @@ export class SeamHttpAcsSystems {
     AcsSystemsGetResponse,
     'acs_system'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/systems/get',
-        method: 'post',
-        data: body,
-      },
-      'acs_system',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/systems/get',
+      method: 'post',
+      body,
+      responseKey: 'acs_system',
+    })
   }
 
   list(
@@ -179,15 +176,12 @@ export class SeamHttpAcsSystems {
     AcsSystemsListResponse,
     'acs_systems'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/systems/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_systems',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/systems/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_systems',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -156,11 +156,7 @@ export class SeamHttpAcsSystems {
 
   get(
     body?: AcsSystemsGetParams,
-  ): SeamHttpRequest<
-    undefined | AcsSystemsGetParams,
-    AcsSystemsGetResponse,
-    'acs_system'
-  > {
+  ): SeamHttpRequest<AcsSystemsGetResponse, 'acs_system'> {
     return new SeamHttpRequest(this, {
       path: '/acs/systems/get',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpAcsSystems {
 
   list(
     body?: AcsSystemsListParams,
-  ): SeamHttpRequest<
-    undefined | AcsSystemsListParams,
-    AcsSystemsListResponse,
-    'acs_systems'
-  > {
+  ): SeamHttpRequest<AcsSystemsListResponse, 'acs_systems'> {
     return new SeamHttpRequest(this, {
       path: '/acs/systems/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,28 +154,40 @@ export class SeamHttpAcsSystems {
     await clientSessions.get()
   }
 
-  async get(
+  get(
     body?: AcsSystemsGetParams,
-  ): Promise<AcsSystemsGetResponse['acs_system']> {
-    const { data } = await this.client.request<AcsSystemsGetResponse>({
-      url: '/acs/systems/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_system
+  ): SeamApiRequest<
+    undefined | AcsSystemsGetParams,
+    AcsSystemsGetResponse,
+    'acs_system'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/systems/get',
+        method: 'post',
+        data: body,
+      },
+      'acs_system',
+    )
   }
 
-  async list(
+  list(
     body?: AcsSystemsListParams,
-  ): Promise<AcsSystemsListResponse['acs_systems']> {
-    const { data } = await this.client.request<AcsSystemsListResponse>({
-      url: '/acs/systems/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_systems
+  ): SeamApiRequest<
+    undefined | AcsSystemsListParams,
+    AcsSystemsListResponse,
+    'acs_systems'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/systems/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_systems',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpAcsSystems {
 
   get(
     body?: AcsSystemsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsSystemsGetParams,
     AcsSystemsGetResponse,
     'acs_system'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/systems/get',
@@ -174,12 +174,12 @@ export class SeamHttpAcsSystems {
 
   list(
     body?: AcsSystemsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsSystemsListParams,
     AcsSystemsListResponse,
     'acs_systems'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/systems/list',

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,12 @@ export class SeamHttpAcsUsers {
 
   addToAccessGroup(
     body?: AcsUsersAddToAccessGroupBody,
-  ): SeamApiRequest<undefined | AcsUsersAddToAccessGroupBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<
+    undefined | AcsUsersAddToAccessGroupBody,
+    void,
+    undefined
+  > {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/add_to_access_group',
@@ -170,12 +174,12 @@ export class SeamHttpAcsUsers {
 
   create(
     body?: AcsUsersCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersCreateBody,
     AcsUsersCreateResponse,
     'acs_user'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/create',
@@ -188,8 +192,8 @@ export class SeamHttpAcsUsers {
 
   delete(
     body?: AcsUsersDeleteBody,
-  ): SeamApiRequest<undefined | AcsUsersDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsUsersDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/delete',
@@ -202,12 +206,12 @@ export class SeamHttpAcsUsers {
 
   get(
     body?: AcsUsersGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersGetParams,
     AcsUsersGetResponse,
     'acs_user'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/get',
@@ -220,12 +224,12 @@ export class SeamHttpAcsUsers {
 
   list(
     body?: AcsUsersListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersListParams,
     AcsUsersListResponse,
     'acs_users'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/list',
@@ -238,12 +242,12 @@ export class SeamHttpAcsUsers {
 
   listAccessibleEntrances(
     body?: AcsUsersListAccessibleEntrancesParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersListAccessibleEntrancesParams,
     AcsUsersListAccessibleEntrancesResponse,
     'acs_entrances'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/list_accessible_entrances',
@@ -256,12 +260,12 @@ export class SeamHttpAcsUsers {
 
   removeFromAccessGroup(
     body?: AcsUsersRemoveFromAccessGroupBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersRemoveFromAccessGroupBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/remove_from_access_group',
@@ -274,12 +278,12 @@ export class SeamHttpAcsUsers {
 
   revokeAccessToAllEntrances(
     body?: AcsUsersRevokeAccessToAllEntrancesBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | AcsUsersRevokeAccessToAllEntrancesBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/revoke_access_to_all_entrances',
@@ -292,8 +296,8 @@ export class SeamHttpAcsUsers {
 
   suspend(
     body?: AcsUsersSuspendBody,
-  ): SeamApiRequest<undefined | AcsUsersSuspendBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsUsersSuspendBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/suspend',
@@ -306,8 +310,8 @@ export class SeamHttpAcsUsers {
 
   unsuspend(
     body?: AcsUsersUnsuspendBody,
-  ): SeamApiRequest<undefined | AcsUsersUnsuspendBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsUsersUnsuspendBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/unsuspend',
@@ -320,8 +324,8 @@ export class SeamHttpAcsUsers {
 
   update(
     body?: AcsUsersUpdateBody,
-  ): SeamApiRequest<undefined | AcsUsersUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | AcsUsersUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/acs/users/update',

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -161,15 +161,12 @@ export class SeamHttpAcsUsers {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/add_to_access_group',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/add_to_access_group',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   create(
@@ -179,29 +176,23 @@ export class SeamHttpAcsUsers {
     AcsUsersCreateResponse,
     'acs_user'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/create',
-        method: 'post',
-        data: body,
-      },
-      'acs_user',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/create',
+      method: 'post',
+      body,
+      responseKey: 'acs_user',
+    })
   }
 
   delete(
     body?: AcsUsersDeleteBody,
   ): SeamHttpRequest<undefined | AcsUsersDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -211,15 +202,12 @@ export class SeamHttpAcsUsers {
     AcsUsersGetResponse,
     'acs_user'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/get',
-        method: 'post',
-        data: body,
-      },
-      'acs_user',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/get',
+      method: 'post',
+      body,
+      responseKey: 'acs_user',
+    })
   }
 
   list(
@@ -229,15 +217,12 @@ export class SeamHttpAcsUsers {
     AcsUsersListResponse,
     'acs_users'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/list',
-        method: 'post',
-        data: body,
-      },
-      'acs_users',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/list',
+      method: 'post',
+      body,
+      responseKey: 'acs_users',
+    })
   }
 
   listAccessibleEntrances(
@@ -247,15 +232,12 @@ export class SeamHttpAcsUsers {
     AcsUsersListAccessibleEntrancesResponse,
     'acs_entrances'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/list_accessible_entrances',
-        method: 'post',
-        data: body,
-      },
-      'acs_entrances',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/list_accessible_entrances',
+      method: 'post',
+      body,
+      responseKey: 'acs_entrances',
+    })
   }
 
   removeFromAccessGroup(
@@ -265,15 +247,12 @@ export class SeamHttpAcsUsers {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/remove_from_access_group',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/remove_from_access_group',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   revokeAccessToAllEntrances(
@@ -283,57 +262,45 @@ export class SeamHttpAcsUsers {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/revoke_access_to_all_entrances',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/revoke_access_to_all_entrances',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   suspend(
     body?: AcsUsersSuspendBody,
   ): SeamHttpRequest<undefined | AcsUsersSuspendBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/suspend',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/suspend',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   unsuspend(
     body?: AcsUsersUnsuspendBody,
   ): SeamHttpRequest<undefined | AcsUsersUnsuspendBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/unsuspend',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/unsuspend',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   update(
     body?: AcsUsersUpdateBody,
   ): SeamHttpRequest<undefined | AcsUsersUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/acs/users/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/acs/users/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,113 +154,182 @@ export class SeamHttpAcsUsers {
     await clientSessions.get()
   }
 
-  async addToAccessGroup(body?: AcsUsersAddToAccessGroupBody): Promise<void> {
-    await this.client.request<AcsUsersAddToAccessGroupResponse>({
-      url: '/acs/users/add_to_access_group',
-      method: 'post',
-      data: body,
-    })
+  addToAccessGroup(
+    body?: AcsUsersAddToAccessGroupBody,
+  ): SeamApiRequest<undefined | AcsUsersAddToAccessGroupBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/add_to_access_group',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async create(
+  create(
     body?: AcsUsersCreateBody,
-  ): Promise<AcsUsersCreateResponse['acs_user']> {
-    const { data } = await this.client.request<AcsUsersCreateResponse>({
-      url: '/acs/users/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_user
+  ): SeamApiRequest<
+    undefined | AcsUsersCreateBody,
+    AcsUsersCreateResponse,
+    'acs_user'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/create',
+        method: 'post',
+        data: body,
+      },
+      'acs_user',
+    )
   }
 
-  async delete(body?: AcsUsersDeleteBody): Promise<void> {
-    await this.client.request<AcsUsersDeleteResponse>({
-      url: '/acs/users/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: AcsUsersDeleteBody,
+  ): SeamApiRequest<undefined | AcsUsersDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: AcsUsersGetParams,
-  ): Promise<AcsUsersGetResponse['acs_user']> {
-    const { data } = await this.client.request<AcsUsersGetResponse>({
-      url: '/acs/users/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_user
+  ): SeamApiRequest<
+    undefined | AcsUsersGetParams,
+    AcsUsersGetResponse,
+    'acs_user'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/get',
+        method: 'post',
+        data: body,
+      },
+      'acs_user',
+    )
   }
 
-  async list(
+  list(
     body?: AcsUsersListParams,
-  ): Promise<AcsUsersListResponse['acs_users']> {
-    const { data } = await this.client.request<AcsUsersListResponse>({
-      url: '/acs/users/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.acs_users
+  ): SeamApiRequest<
+    undefined | AcsUsersListParams,
+    AcsUsersListResponse,
+    'acs_users'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/list',
+        method: 'post',
+        data: body,
+      },
+      'acs_users',
+    )
   }
 
-  async listAccessibleEntrances(
+  listAccessibleEntrances(
     body?: AcsUsersListAccessibleEntrancesParams,
-  ): Promise<AcsUsersListAccessibleEntrancesResponse['acs_entrances']> {
-    const { data } =
-      await this.client.request<AcsUsersListAccessibleEntrancesResponse>({
+  ): SeamApiRequest<
+    undefined | AcsUsersListAccessibleEntrancesParams,
+    AcsUsersListAccessibleEntrancesResponse,
+    'acs_entrances'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/acs/users/list_accessible_entrances',
         method: 'post',
         data: body,
-      })
-
-    return data.acs_entrances
+      },
+      'acs_entrances',
+    )
   }
 
-  async removeFromAccessGroup(
+  removeFromAccessGroup(
     body?: AcsUsersRemoveFromAccessGroupBody,
-  ): Promise<void> {
-    await this.client.request<AcsUsersRemoveFromAccessGroupResponse>({
-      url: '/acs/users/remove_from_access_group',
-      method: 'post',
-      data: body,
-    })
+  ): SeamApiRequest<
+    undefined | AcsUsersRemoveFromAccessGroupBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/remove_from_access_group',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async revokeAccessToAllEntrances(
+  revokeAccessToAllEntrances(
     body?: AcsUsersRevokeAccessToAllEntrancesBody,
-  ): Promise<void> {
-    await this.client.request<AcsUsersRevokeAccessToAllEntrancesResponse>({
-      url: '/acs/users/revoke_access_to_all_entrances',
-      method: 'post',
-      data: body,
-    })
+  ): SeamApiRequest<
+    undefined | AcsUsersRevokeAccessToAllEntrancesBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/revoke_access_to_all_entrances',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async suspend(body?: AcsUsersSuspendBody): Promise<void> {
-    await this.client.request<AcsUsersSuspendResponse>({
-      url: '/acs/users/suspend',
-      method: 'post',
-      data: body,
-    })
+  suspend(
+    body?: AcsUsersSuspendBody,
+  ): SeamApiRequest<undefined | AcsUsersSuspendBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/suspend',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async unsuspend(body?: AcsUsersUnsuspendBody): Promise<void> {
-    await this.client.request<AcsUsersUnsuspendResponse>({
-      url: '/acs/users/unsuspend',
-      method: 'post',
-      data: body,
-    })
+  unsuspend(
+    body?: AcsUsersUnsuspendBody,
+  ): SeamApiRequest<undefined | AcsUsersUnsuspendBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/unsuspend',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async update(body?: AcsUsersUpdateBody): Promise<void> {
-    await this.client.request<AcsUsersUpdateResponse>({
-      url: '/acs/users/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: AcsUsersUpdateBody,
+  ): SeamApiRequest<undefined | AcsUsersUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/acs/users/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -156,11 +156,7 @@ export class SeamHttpAcsUsers {
 
   addToAccessGroup(
     body?: AcsUsersAddToAccessGroupBody,
-  ): SeamHttpRequest<
-    undefined | AcsUsersAddToAccessGroupBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/add_to_access_group',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpAcsUsers {
 
   create(
     body?: AcsUsersCreateBody,
-  ): SeamHttpRequest<
-    undefined | AcsUsersCreateBody,
-    AcsUsersCreateResponse,
-    'acs_user'
-  > {
+  ): SeamHttpRequest<AcsUsersCreateResponse, 'acs_user'> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/create',
       method: 'post',
@@ -184,9 +176,7 @@ export class SeamHttpAcsUsers {
     })
   }
 
-  delete(
-    body?: AcsUsersDeleteBody,
-  ): SeamHttpRequest<undefined | AcsUsersDeleteBody, void, undefined> {
+  delete(body?: AcsUsersDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/delete',
       method: 'post',
@@ -197,11 +187,7 @@ export class SeamHttpAcsUsers {
 
   get(
     body?: AcsUsersGetParams,
-  ): SeamHttpRequest<
-    undefined | AcsUsersGetParams,
-    AcsUsersGetResponse,
-    'acs_user'
-  > {
+  ): SeamHttpRequest<AcsUsersGetResponse, 'acs_user'> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/get',
       method: 'post',
@@ -212,11 +198,7 @@ export class SeamHttpAcsUsers {
 
   list(
     body?: AcsUsersListParams,
-  ): SeamHttpRequest<
-    undefined | AcsUsersListParams,
-    AcsUsersListResponse,
-    'acs_users'
-  > {
+  ): SeamHttpRequest<AcsUsersListResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/list',
       method: 'post',
@@ -227,11 +209,7 @@ export class SeamHttpAcsUsers {
 
   listAccessibleEntrances(
     body?: AcsUsersListAccessibleEntrancesParams,
-  ): SeamHttpRequest<
-    undefined | AcsUsersListAccessibleEntrancesParams,
-    AcsUsersListAccessibleEntrancesResponse,
-    'acs_entrances'
-  > {
+  ): SeamHttpRequest<AcsUsersListAccessibleEntrancesResponse, 'acs_entrances'> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/list_accessible_entrances',
       method: 'post',
@@ -242,11 +220,7 @@ export class SeamHttpAcsUsers {
 
   removeFromAccessGroup(
     body?: AcsUsersRemoveFromAccessGroupBody,
-  ): SeamHttpRequest<
-    undefined | AcsUsersRemoveFromAccessGroupBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/remove_from_access_group',
       method: 'post',
@@ -257,11 +231,7 @@ export class SeamHttpAcsUsers {
 
   revokeAccessToAllEntrances(
     body?: AcsUsersRevokeAccessToAllEntrancesBody,
-  ): SeamHttpRequest<
-    undefined | AcsUsersRevokeAccessToAllEntrancesBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/revoke_access_to_all_entrances',
       method: 'post',
@@ -270,9 +240,7 @@ export class SeamHttpAcsUsers {
     })
   }
 
-  suspend(
-    body?: AcsUsersSuspendBody,
-  ): SeamHttpRequest<undefined | AcsUsersSuspendBody, void, undefined> {
+  suspend(body?: AcsUsersSuspendBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/suspend',
       method: 'post',
@@ -281,9 +249,7 @@ export class SeamHttpAcsUsers {
     })
   }
 
-  unsuspend(
-    body?: AcsUsersUnsuspendBody,
-  ): SeamHttpRequest<undefined | AcsUsersUnsuspendBody, void, undefined> {
+  unsuspend(body?: AcsUsersUnsuspendBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/unsuspend',
       method: 'post',
@@ -292,9 +258,7 @@ export class SeamHttpAcsUsers {
     })
   }
 
-  update(
-    body?: AcsUsersUpdateBody,
-  ): SeamHttpRequest<undefined | AcsUsersUpdateBody, void, undefined> {
+  update(body?: AcsUsersUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/acs/users/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -157,12 +157,12 @@ export class SeamHttpActionAttempts {
   get(
     body?: ActionAttemptsGetParams,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ActionAttemptsGetParams,
     ActionAttemptsGetResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/action_attempts/get',
@@ -176,12 +176,12 @@ export class SeamHttpActionAttempts {
 
   list(
     body?: ActionAttemptsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ActionAttemptsListParams,
     ActionAttemptsListResponse,
     'action_attempts'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/action_attempts/list',

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -157,11 +157,7 @@ export class SeamHttpActionAttempts {
   get(
     body?: ActionAttemptsGetParams,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ActionAttemptsGetParams,
-    ActionAttemptsGetResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ActionAttemptsGetResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/action_attempts/get',
       method: 'post',
@@ -173,11 +169,7 @@ export class SeamHttpActionAttempts {
 
   list(
     body?: ActionAttemptsListParams,
-  ): SeamHttpRequest<
-    undefined | ActionAttemptsListParams,
-    ActionAttemptsListResponse,
-    'action_attempts'
-  > {
+  ): SeamHttpRequest<ActionAttemptsListResponse, 'action_attempts'> {
     return new SeamHttpRequest(this, {
       path: '/action_attempts/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { resolveActionAttempt } from 'lib/seam/connect/resolve-action-attempt.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -154,40 +154,42 @@ export class SeamHttpActionAttempts {
     await clientSessions.get()
   }
 
-  async get(
+  get(
     body?: ActionAttemptsGetParams,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ActionAttemptsGetResponse['action_attempt']> {
-    const { data } = await this.client.request<ActionAttemptsGetResponse>({
-      url: '/action_attempts/get',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ActionAttemptsGetParams,
+    ActionAttemptsGetResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/action_attempts/get',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async list(
+  list(
     body?: ActionAttemptsListParams,
-  ): Promise<ActionAttemptsListResponse['action_attempts']> {
-    const { data } = await this.client.request<ActionAttemptsListResponse>({
-      url: '/action_attempts/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.action_attempts
+  ): SeamApiRequest<
+    undefined | ActionAttemptsListParams,
+    ActionAttemptsListResponse,
+    'action_attempts'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/action_attempts/list',
+        method: 'post',
+        data: body,
+      },
+      'action_attempts',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -162,16 +162,13 @@ export class SeamHttpActionAttempts {
     ActionAttemptsGetResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/action_attempts/get',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/action_attempts/get',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   list(
@@ -181,15 +178,12 @@ export class SeamHttpActionAttempts {
     ActionAttemptsListResponse,
     'action_attempts'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/action_attempts/list',
-        method: 'post',
-        data: body,
-      },
-      'action_attempts',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/action_attempts/list',
+      method: 'post',
+      body,
+      responseKey: 'action_attempts',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 export class SeamHttpClientSessions {
   client: Client
@@ -154,12 +154,12 @@ export class SeamHttpClientSessions {
 
   create(
     body?: ClientSessionsCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ClientSessionsCreateBody,
     ClientSessionsCreateResponse,
     'client_session'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/create',
@@ -172,8 +172,8 @@ export class SeamHttpClientSessions {
 
   delete(
     body?: ClientSessionsDeleteBody,
-  ): SeamApiRequest<undefined | ClientSessionsDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ClientSessionsDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/delete',
@@ -186,12 +186,12 @@ export class SeamHttpClientSessions {
 
   get(
     body?: ClientSessionsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ClientSessionsGetParams,
     ClientSessionsGetResponse,
     'client_session'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/get',
@@ -204,12 +204,12 @@ export class SeamHttpClientSessions {
 
   getOrCreate(
     body?: ClientSessionsGetOrCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ClientSessionsGetOrCreateBody,
     ClientSessionsGetOrCreateResponse,
     'client_session'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/get_or_create',
@@ -222,12 +222,12 @@ export class SeamHttpClientSessions {
 
   grantAccess(
     body?: ClientSessionsGrantAccessBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ClientSessionsGrantAccessBody,
     ClientSessionsGrantAccessResponse,
     'client_session'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/grant_access',
@@ -240,12 +240,12 @@ export class SeamHttpClientSessions {
 
   list(
     body?: ClientSessionsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ClientSessionsListParams,
     ClientSessionsListResponse,
     'client_sessions'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/list',
@@ -258,8 +258,8 @@ export class SeamHttpClientSessions {
 
   revoke(
     body?: ClientSessionsRevokeBody,
-  ): SeamApiRequest<undefined | ClientSessionsRevokeBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ClientSessionsRevokeBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/client_sessions/revoke',

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -154,11 +154,7 @@ export class SeamHttpClientSessions {
 
   create(
     body?: ClientSessionsCreateBody,
-  ): SeamHttpRequest<
-    undefined | ClientSessionsCreateBody,
-    ClientSessionsCreateResponse,
-    'client_session'
-  > {
+  ): SeamHttpRequest<ClientSessionsCreateResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/create',
       method: 'post',
@@ -167,9 +163,7 @@ export class SeamHttpClientSessions {
     })
   }
 
-  delete(
-    body?: ClientSessionsDeleteBody,
-  ): SeamHttpRequest<undefined | ClientSessionsDeleteBody, void, undefined> {
+  delete(body?: ClientSessionsDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/delete',
       method: 'post',
@@ -180,11 +174,7 @@ export class SeamHttpClientSessions {
 
   get(
     body?: ClientSessionsGetParams,
-  ): SeamHttpRequest<
-    undefined | ClientSessionsGetParams,
-    ClientSessionsGetResponse,
-    'client_session'
-  > {
+  ): SeamHttpRequest<ClientSessionsGetResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/get',
       method: 'post',
@@ -195,11 +185,7 @@ export class SeamHttpClientSessions {
 
   getOrCreate(
     body?: ClientSessionsGetOrCreateBody,
-  ): SeamHttpRequest<
-    undefined | ClientSessionsGetOrCreateBody,
-    ClientSessionsGetOrCreateResponse,
-    'client_session'
-  > {
+  ): SeamHttpRequest<ClientSessionsGetOrCreateResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/get_or_create',
       method: 'post',
@@ -210,11 +196,7 @@ export class SeamHttpClientSessions {
 
   grantAccess(
     body?: ClientSessionsGrantAccessBody,
-  ): SeamHttpRequest<
-    undefined | ClientSessionsGrantAccessBody,
-    ClientSessionsGrantAccessResponse,
-    'client_session'
-  > {
+  ): SeamHttpRequest<ClientSessionsGrantAccessResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/grant_access',
       method: 'post',
@@ -225,11 +207,7 @@ export class SeamHttpClientSessions {
 
   list(
     body?: ClientSessionsListParams,
-  ): SeamHttpRequest<
-    undefined | ClientSessionsListParams,
-    ClientSessionsListResponse,
-    'client_sessions'
-  > {
+  ): SeamHttpRequest<ClientSessionsListResponse, 'client_sessions'> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/list',
       method: 'post',
@@ -238,9 +216,7 @@ export class SeamHttpClientSessions {
     })
   }
 
-  revoke(
-    body?: ClientSessionsRevokeBody,
-  ): SeamHttpRequest<undefined | ClientSessionsRevokeBody, void, undefined> {
+  revoke(body?: ClientSessionsRevokeBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/client_sessions/revoke',
       method: 'post',

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -159,29 +159,23 @@ export class SeamHttpClientSessions {
     ClientSessionsCreateResponse,
     'client_session'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/create',
-        method: 'post',
-        data: body,
-      },
-      'client_session',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/create',
+      method: 'post',
+      body,
+      responseKey: 'client_session',
+    })
   }
 
   delete(
     body?: ClientSessionsDeleteBody,
   ): SeamHttpRequest<undefined | ClientSessionsDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -191,15 +185,12 @@ export class SeamHttpClientSessions {
     ClientSessionsGetResponse,
     'client_session'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/get',
-        method: 'post',
-        data: body,
-      },
-      'client_session',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/get',
+      method: 'post',
+      body,
+      responseKey: 'client_session',
+    })
   }
 
   getOrCreate(
@@ -209,15 +200,12 @@ export class SeamHttpClientSessions {
     ClientSessionsGetOrCreateResponse,
     'client_session'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/get_or_create',
-        method: 'post',
-        data: body,
-      },
-      'client_session',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/get_or_create',
+      method: 'post',
+      body,
+      responseKey: 'client_session',
+    })
   }
 
   grantAccess(
@@ -227,15 +215,12 @@ export class SeamHttpClientSessions {
     ClientSessionsGrantAccessResponse,
     'client_session'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/grant_access',
-        method: 'post',
-        data: body,
-      },
-      'client_session',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/grant_access',
+      method: 'post',
+      body,
+      responseKey: 'client_session',
+    })
   }
 
   list(
@@ -245,29 +230,23 @@ export class SeamHttpClientSessions {
     ClientSessionsListResponse,
     'client_sessions'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/list',
-        method: 'post',
-        data: body,
-      },
-      'client_sessions',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/list',
+      method: 'post',
+      body,
+      responseKey: 'client_sessions',
+    })
   }
 
   revoke(
     body?: ClientSessionsRevokeBody,
   ): SeamHttpRequest<undefined | ClientSessionsRevokeBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/client_sessions/revoke',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/client_sessions/revoke',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 export class SeamHttpClientSessions {
   client: Client
@@ -151,82 +152,122 @@ export class SeamHttpClientSessions {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: ClientSessionsCreateBody,
-  ): Promise<ClientSessionsCreateResponse['client_session']> {
-    const { data } = await this.client.request<ClientSessionsCreateResponse>({
-      url: '/client_sessions/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.client_session
+  ): SeamApiRequest<
+    undefined | ClientSessionsCreateBody,
+    ClientSessionsCreateResponse,
+    'client_session'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/client_sessions/create',
+        method: 'post',
+        data: body,
+      },
+      'client_session',
+    )
   }
 
-  async delete(body?: ClientSessionsDeleteBody): Promise<void> {
-    await this.client.request<ClientSessionsDeleteResponse>({
-      url: '/client_sessions/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: ClientSessionsDeleteBody,
+  ): SeamApiRequest<undefined | ClientSessionsDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/client_sessions/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: ClientSessionsGetParams,
-  ): Promise<ClientSessionsGetResponse['client_session']> {
-    const { data } = await this.client.request<ClientSessionsGetResponse>({
-      url: '/client_sessions/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.client_session
+  ): SeamApiRequest<
+    undefined | ClientSessionsGetParams,
+    ClientSessionsGetResponse,
+    'client_session'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/client_sessions/get',
+        method: 'post',
+        data: body,
+      },
+      'client_session',
+    )
   }
 
-  async getOrCreate(
+  getOrCreate(
     body?: ClientSessionsGetOrCreateBody,
-  ): Promise<ClientSessionsGetOrCreateResponse['client_session']> {
-    const { data } =
-      await this.client.request<ClientSessionsGetOrCreateResponse>({
+  ): SeamApiRequest<
+    undefined | ClientSessionsGetOrCreateBody,
+    ClientSessionsGetOrCreateResponse,
+    'client_session'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/client_sessions/get_or_create',
         method: 'post',
         data: body,
-      })
-
-    return data.client_session
+      },
+      'client_session',
+    )
   }
 
-  async grantAccess(
+  grantAccess(
     body?: ClientSessionsGrantAccessBody,
-  ): Promise<ClientSessionsGrantAccessResponse['client_session']> {
-    const { data } =
-      await this.client.request<ClientSessionsGrantAccessResponse>({
+  ): SeamApiRequest<
+    undefined | ClientSessionsGrantAccessBody,
+    ClientSessionsGrantAccessResponse,
+    'client_session'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/client_sessions/grant_access',
         method: 'post',
         data: body,
-      })
-
-    return data.client_session
+      },
+      'client_session',
+    )
   }
 
-  async list(
+  list(
     body?: ClientSessionsListParams,
-  ): Promise<ClientSessionsListResponse['client_sessions']> {
-    const { data } = await this.client.request<ClientSessionsListResponse>({
-      url: '/client_sessions/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.client_sessions
+  ): SeamApiRequest<
+    undefined | ClientSessionsListParams,
+    ClientSessionsListResponse,
+    'client_sessions'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/client_sessions/list',
+        method: 'post',
+        data: body,
+      },
+      'client_sessions',
+    )
   }
 
-  async revoke(body?: ClientSessionsRevokeBody): Promise<void> {
-    await this.client.request<ClientSessionsRevokeResponse>({
-      url: '/client_sessions/revoke',
-      method: 'post',
-      data: body,
-    })
+  revoke(
+    body?: ClientSessionsRevokeBody,
+  ): SeamApiRequest<undefined | ClientSessionsRevokeBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/client_sessions/revoke',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -160,11 +160,7 @@ export class SeamHttpConnectWebviews {
 
   create(
     body?: ConnectWebviewsCreateBody,
-  ): SeamHttpRequest<
-    undefined | ConnectWebviewsCreateBody,
-    ConnectWebviewsCreateResponse,
-    'connect_webview'
-  > {
+  ): SeamHttpRequest<ConnectWebviewsCreateResponse, 'connect_webview'> {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/create',
       method: 'post',
@@ -173,9 +169,7 @@ export class SeamHttpConnectWebviews {
     })
   }
 
-  delete(
-    body?: ConnectWebviewsDeleteBody,
-  ): SeamHttpRequest<undefined | ConnectWebviewsDeleteBody, void, undefined> {
+  delete(body?: ConnectWebviewsDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/delete',
       method: 'post',
@@ -186,11 +180,7 @@ export class SeamHttpConnectWebviews {
 
   get(
     body?: ConnectWebviewsGetParams,
-  ): SeamHttpRequest<
-    undefined | ConnectWebviewsGetParams,
-    ConnectWebviewsGetResponse,
-    'connect_webview'
-  > {
+  ): SeamHttpRequest<ConnectWebviewsGetResponse, 'connect_webview'> {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/get',
       method: 'post',
@@ -201,11 +191,7 @@ export class SeamHttpConnectWebviews {
 
   list(
     body?: ConnectWebviewsListParams,
-  ): SeamHttpRequest<
-    undefined | ConnectWebviewsListParams,
-    ConnectWebviewsListResponse,
-    'connect_webviews'
-  > {
+  ): SeamHttpRequest<ConnectWebviewsListResponse, 'connect_webviews'> {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/list',
       method: 'post',
@@ -214,9 +200,7 @@ export class SeamHttpConnectWebviews {
     })
   }
 
-  view(
-    params?: ConnectWebviewsViewParams,
-  ): SeamHttpRequest<undefined | ConnectWebviewsViewParams, void, undefined> {
+  view(params?: ConnectWebviewsViewParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/view',
       method: 'get',

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -35,6 +35,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -157,56 +158,86 @@ export class SeamHttpConnectWebviews {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: ConnectWebviewsCreateBody,
-  ): Promise<ConnectWebviewsCreateResponse['connect_webview']> {
-    const { data } = await this.client.request<ConnectWebviewsCreateResponse>({
-      url: '/connect_webviews/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.connect_webview
+  ): SeamApiRequest<
+    undefined | ConnectWebviewsCreateBody,
+    ConnectWebviewsCreateResponse,
+    'connect_webview'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connect_webviews/create',
+        method: 'post',
+        data: body,
+      },
+      'connect_webview',
+    )
   }
 
-  async delete(body?: ConnectWebviewsDeleteBody): Promise<void> {
-    await this.client.request<ConnectWebviewsDeleteResponse>({
-      url: '/connect_webviews/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: ConnectWebviewsDeleteBody,
+  ): SeamApiRequest<undefined | ConnectWebviewsDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connect_webviews/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: ConnectWebviewsGetParams,
-  ): Promise<ConnectWebviewsGetResponse['connect_webview']> {
-    const { data } = await this.client.request<ConnectWebviewsGetResponse>({
-      url: '/connect_webviews/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.connect_webview
+  ): SeamApiRequest<
+    undefined | ConnectWebviewsGetParams,
+    ConnectWebviewsGetResponse,
+    'connect_webview'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connect_webviews/get',
+        method: 'post',
+        data: body,
+      },
+      'connect_webview',
+    )
   }
 
-  async list(
+  list(
     body?: ConnectWebviewsListParams,
-  ): Promise<ConnectWebviewsListResponse['connect_webviews']> {
-    const { data } = await this.client.request<ConnectWebviewsListResponse>({
-      url: '/connect_webviews/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.connect_webviews
+  ): SeamApiRequest<
+    undefined | ConnectWebviewsListParams,
+    ConnectWebviewsListResponse,
+    'connect_webviews'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connect_webviews/list',
+        method: 'post',
+        data: body,
+      },
+      'connect_webviews',
+    )
   }
 
-  async view(params?: ConnectWebviewsViewParams): Promise<void> {
-    await this.client.request<ConnectWebviewsViewResponse>({
-      url: '/connect_webviews/view',
-      method: 'get',
-      params,
-    })
+  view(
+    params?: ConnectWebviewsViewParams,
+  ): SeamApiRequest<undefined | ConnectWebviewsViewParams, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connect_webviews/view',
+        method: 'get',
+        params,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -220,7 +220,7 @@ export class SeamHttpConnectWebviews {
     return new SeamHttpRequest(this, {
       path: '/connect_webviews/view',
       method: 'get',
-      query: params,
+      params,
       responseKey: undefined,
     })
   }

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -165,29 +165,23 @@ export class SeamHttpConnectWebviews {
     ConnectWebviewsCreateResponse,
     'connect_webview'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connect_webviews/create',
-        method: 'post',
-        data: body,
-      },
-      'connect_webview',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connect_webviews/create',
+      method: 'post',
+      body,
+      responseKey: 'connect_webview',
+    })
   }
 
   delete(
     body?: ConnectWebviewsDeleteBody,
   ): SeamHttpRequest<undefined | ConnectWebviewsDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connect_webviews/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connect_webviews/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -197,15 +191,12 @@ export class SeamHttpConnectWebviews {
     ConnectWebviewsGetResponse,
     'connect_webview'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connect_webviews/get',
-        method: 'post',
-        data: body,
-      },
-      'connect_webview',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connect_webviews/get',
+      method: 'post',
+      body,
+      responseKey: 'connect_webview',
+    })
   }
 
   list(
@@ -215,29 +206,23 @@ export class SeamHttpConnectWebviews {
     ConnectWebviewsListResponse,
     'connect_webviews'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connect_webviews/list',
-        method: 'post',
-        data: body,
-      },
-      'connect_webviews',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connect_webviews/list',
+      method: 'post',
+      body,
+      responseKey: 'connect_webviews',
+    })
   }
 
   view(
     params?: ConnectWebviewsViewParams,
   ): SeamHttpRequest<undefined | ConnectWebviewsViewParams, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connect_webviews/view',
-        method: 'get',
-        params,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connect_webviews/view',
+      method: 'get',
+      query: params,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -35,7 +35,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -160,12 +160,12 @@ export class SeamHttpConnectWebviews {
 
   create(
     body?: ConnectWebviewsCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectWebviewsCreateBody,
     ConnectWebviewsCreateResponse,
     'connect_webview'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connect_webviews/create',
@@ -178,8 +178,8 @@ export class SeamHttpConnectWebviews {
 
   delete(
     body?: ConnectWebviewsDeleteBody,
-  ): SeamApiRequest<undefined | ConnectWebviewsDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ConnectWebviewsDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/connect_webviews/delete',
@@ -192,12 +192,12 @@ export class SeamHttpConnectWebviews {
 
   get(
     body?: ConnectWebviewsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectWebviewsGetParams,
     ConnectWebviewsGetResponse,
     'connect_webview'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connect_webviews/get',
@@ -210,12 +210,12 @@ export class SeamHttpConnectWebviews {
 
   list(
     body?: ConnectWebviewsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectWebviewsListParams,
     ConnectWebviewsListResponse,
     'connect_webviews'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connect_webviews/list',
@@ -228,8 +228,8 @@ export class SeamHttpConnectWebviews {
 
   view(
     params?: ConnectWebviewsViewParams,
-  ): SeamApiRequest<undefined | ConnectWebviewsViewParams, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ConnectWebviewsViewParams, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/connect_webviews/view',

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -154,9 +154,7 @@ export class SeamHttpConnectedAccounts {
     await clientSessions.get()
   }
 
-  delete(
-    body?: ConnectedAccountsDeleteBody,
-  ): SeamHttpRequest<undefined | ConnectedAccountsDeleteBody, void, undefined> {
+  delete(body?: ConnectedAccountsDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/connected_accounts/delete',
       method: 'post',
@@ -167,11 +165,7 @@ export class SeamHttpConnectedAccounts {
 
   get(
     body?: ConnectedAccountsGetParams,
-  ): SeamHttpRequest<
-    undefined | ConnectedAccountsGetParams,
-    ConnectedAccountsGetResponse,
-    'connected_account'
-  > {
+  ): SeamHttpRequest<ConnectedAccountsGetResponse, 'connected_account'> {
     return new SeamHttpRequest(this, {
       path: '/connected_accounts/get',
       method: 'post',
@@ -182,11 +176,7 @@ export class SeamHttpConnectedAccounts {
 
   list(
     body?: ConnectedAccountsListParams,
-  ): SeamHttpRequest<
-    undefined | ConnectedAccountsListParams,
-    ConnectedAccountsListResponse,
-    'connected_accounts'
-  > {
+  ): SeamHttpRequest<ConnectedAccountsListResponse, 'connected_accounts'> {
     return new SeamHttpRequest(this, {
       path: '/connected_accounts/list',
       method: 'post',
@@ -197,11 +187,7 @@ export class SeamHttpConnectedAccounts {
 
   update(
     body?: ConnectedAccountsUpdateBody,
-  ): SeamHttpRequest<
-    undefined | ConnectedAccountsUpdateBody,
-    ConnectedAccountsUpdateResponse,
-    'connected_account'
-  > {
+  ): SeamHttpRequest<ConnectedAccountsUpdateResponse, 'connected_account'> {
     return new SeamHttpRequest(this, {
       path: '/connected_accounts/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,50 +154,72 @@ export class SeamHttpConnectedAccounts {
     await clientSessions.get()
   }
 
-  async delete(body?: ConnectedAccountsDeleteBody): Promise<void> {
-    await this.client.request<ConnectedAccountsDeleteResponse>({
-      url: '/connected_accounts/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: ConnectedAccountsDeleteBody,
+  ): SeamApiRequest<undefined | ConnectedAccountsDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connected_accounts/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: ConnectedAccountsGetParams,
-  ): Promise<ConnectedAccountsGetResponse['connected_account']> {
-    const { data } = await this.client.request<ConnectedAccountsGetResponse>({
-      url: '/connected_accounts/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.connected_account
+  ): SeamApiRequest<
+    undefined | ConnectedAccountsGetParams,
+    ConnectedAccountsGetResponse,
+    'connected_account'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connected_accounts/get',
+        method: 'post',
+        data: body,
+      },
+      'connected_account',
+    )
   }
 
-  async list(
+  list(
     body?: ConnectedAccountsListParams,
-  ): Promise<ConnectedAccountsListResponse['connected_accounts']> {
-    const { data } = await this.client.request<ConnectedAccountsListResponse>({
-      url: '/connected_accounts/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.connected_accounts
+  ): SeamApiRequest<
+    undefined | ConnectedAccountsListParams,
+    ConnectedAccountsListResponse,
+    'connected_accounts'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/connected_accounts/list',
+        method: 'post',
+        data: body,
+      },
+      'connected_accounts',
+    )
   }
 
-  async update(
+  update(
     body?: ConnectedAccountsUpdateBody,
-  ): Promise<ConnectedAccountsUpdateResponse['connected_account']> {
-    const { data } = await this.client.request<ConnectedAccountsUpdateResponse>(
+  ): SeamApiRequest<
+    undefined | ConnectedAccountsUpdateBody,
+    ConnectedAccountsUpdateResponse,
+    'connected_account'
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/connected_accounts/update',
         method: 'post',
         data: body,
       },
+      'connected_account',
     )
-
-    return data.connected_account
   }
 }
 

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,8 @@ export class SeamHttpConnectedAccounts {
 
   delete(
     body?: ConnectedAccountsDeleteBody,
-  ): SeamApiRequest<undefined | ConnectedAccountsDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ConnectedAccountsDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/connected_accounts/delete',
@@ -170,12 +170,12 @@ export class SeamHttpConnectedAccounts {
 
   get(
     body?: ConnectedAccountsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectedAccountsGetParams,
     ConnectedAccountsGetResponse,
     'connected_account'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connected_accounts/get',
@@ -188,12 +188,12 @@ export class SeamHttpConnectedAccounts {
 
   list(
     body?: ConnectedAccountsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectedAccountsListParams,
     ConnectedAccountsListResponse,
     'connected_accounts'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connected_accounts/list',
@@ -206,12 +206,12 @@ export class SeamHttpConnectedAccounts {
 
   update(
     body?: ConnectedAccountsUpdateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ConnectedAccountsUpdateBody,
     ConnectedAccountsUpdateResponse,
     'connected_account'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/connected_accounts/update',

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -157,15 +157,12 @@ export class SeamHttpConnectedAccounts {
   delete(
     body?: ConnectedAccountsDeleteBody,
   ): SeamHttpRequest<undefined | ConnectedAccountsDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connected_accounts/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connected_accounts/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -175,15 +172,12 @@ export class SeamHttpConnectedAccounts {
     ConnectedAccountsGetResponse,
     'connected_account'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connected_accounts/get',
-        method: 'post',
-        data: body,
-      },
-      'connected_account',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connected_accounts/get',
+      method: 'post',
+      body,
+      responseKey: 'connected_account',
+    })
   }
 
   list(
@@ -193,15 +187,12 @@ export class SeamHttpConnectedAccounts {
     ConnectedAccountsListResponse,
     'connected_accounts'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connected_accounts/list',
-        method: 'post',
-        data: body,
-      },
-      'connected_accounts',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connected_accounts/list',
+      method: 'post',
+      body,
+      responseKey: 'connected_accounts',
+    })
   }
 
   update(
@@ -211,15 +202,12 @@ export class SeamHttpConnectedAccounts {
     ConnectedAccountsUpdateResponse,
     'connected_account'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/connected_accounts/update',
-        method: 'post',
-        data: body,
-      },
-      'connected_account',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/connected_accounts/update',
+      method: 'post',
+      body,
+      responseKey: 'connected_account',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/devices-simulate.ts
+++ b/src/lib/seam/connect/routes/devices-simulate.ts
@@ -157,15 +157,12 @@ export class SeamHttpDevicesSimulate {
   remove(
     body?: DevicesSimulateRemoveBody,
   ): SeamHttpRequest<undefined | DevicesSimulateRemoveBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/simulate/remove',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/simulate/remove',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/devices-simulate.ts
+++ b/src/lib/seam/connect/routes/devices-simulate.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,8 @@ export class SeamHttpDevicesSimulate {
 
   remove(
     body?: DevicesSimulateRemoveBody,
-  ): SeamApiRequest<undefined | DevicesSimulateRemoveBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | DevicesSimulateRemoveBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/simulate/remove',

--- a/src/lib/seam/connect/routes/devices-simulate.ts
+++ b/src/lib/seam/connect/routes/devices-simulate.ts
@@ -154,9 +154,7 @@ export class SeamHttpDevicesSimulate {
     await clientSessions.get()
   }
 
-  remove(
-    body?: DevicesSimulateRemoveBody,
-  ): SeamHttpRequest<undefined | DevicesSimulateRemoveBody, void, undefined> {
+  remove(body?: DevicesSimulateRemoveBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/devices/simulate/remove',
       method: 'post',

--- a/src/lib/seam/connect/routes/devices-simulate.ts
+++ b/src/lib/seam/connect/routes/devices-simulate.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,12 +154,18 @@ export class SeamHttpDevicesSimulate {
     await clientSessions.get()
   }
 
-  async remove(body?: DevicesSimulateRemoveBody): Promise<void> {
-    await this.client.request<DevicesSimulateRemoveResponse>({
-      url: '/devices/simulate/remove',
-      method: 'post',
-      data: body,
-    })
+  remove(
+    body?: DevicesSimulateRemoveBody,
+  ): SeamApiRequest<undefined | DevicesSimulateRemoveBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/simulate/remove',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -156,11 +156,7 @@ export class SeamHttpDevicesUnmanaged {
 
   get(
     body?: DevicesUnmanagedGetParams,
-  ): SeamHttpRequest<
-    undefined | DevicesUnmanagedGetParams,
-    DevicesUnmanagedGetResponse,
-    'device'
-  > {
+  ): SeamHttpRequest<DevicesUnmanagedGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
       path: '/devices/unmanaged/get',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpDevicesUnmanaged {
 
   list(
     body?: DevicesUnmanagedListParams,
-  ): SeamHttpRequest<
-    undefined | DevicesUnmanagedListParams,
-    DevicesUnmanagedListResponse,
-    'devices'
-  > {
+  ): SeamHttpRequest<DevicesUnmanagedListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
       path: '/devices/unmanaged/list',
       method: 'post',
@@ -184,9 +176,7 @@ export class SeamHttpDevicesUnmanaged {
     })
   }
 
-  update(
-    body?: DevicesUnmanagedUpdateBody,
-  ): SeamHttpRequest<undefined | DevicesUnmanagedUpdateBody, void, undefined> {
+  update(body?: DevicesUnmanagedUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/devices/unmanaged/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -161,15 +161,12 @@ export class SeamHttpDevicesUnmanaged {
     DevicesUnmanagedGetResponse,
     'device'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/unmanaged/get',
-        method: 'post',
-        data: body,
-      },
-      'device',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/unmanaged/get',
+      method: 'post',
+      body,
+      responseKey: 'device',
+    })
   }
 
   list(
@@ -179,29 +176,23 @@ export class SeamHttpDevicesUnmanaged {
     DevicesUnmanagedListResponse,
     'devices'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/unmanaged/list',
-        method: 'post',
-        data: body,
-      },
-      'devices',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/unmanaged/list',
+      method: 'post',
+      body,
+      responseKey: 'devices',
+    })
   }
 
   update(
     body?: DevicesUnmanagedUpdateBody,
   ): SeamHttpRequest<undefined | DevicesUnmanagedUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/unmanaged/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/unmanaged/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpDevicesUnmanaged {
 
   get(
     body?: DevicesUnmanagedGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | DevicesUnmanagedGetParams,
     DevicesUnmanagedGetResponse,
     'device'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/unmanaged/get',
@@ -174,12 +174,12 @@ export class SeamHttpDevicesUnmanaged {
 
   list(
     body?: DevicesUnmanagedListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | DevicesUnmanagedListParams,
     DevicesUnmanagedListResponse,
     'devices'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/unmanaged/list',
@@ -192,8 +192,8 @@ export class SeamHttpDevicesUnmanaged {
 
   update(
     body?: DevicesUnmanagedUpdateBody,
-  ): SeamApiRequest<undefined | DevicesUnmanagedUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | DevicesUnmanagedUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/unmanaged/update',

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,36 +154,54 @@ export class SeamHttpDevicesUnmanaged {
     await clientSessions.get()
   }
 
-  async get(
+  get(
     body?: DevicesUnmanagedGetParams,
-  ): Promise<DevicesUnmanagedGetResponse['device']> {
-    const { data } = await this.client.request<DevicesUnmanagedGetResponse>({
-      url: '/devices/unmanaged/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.device
+  ): SeamApiRequest<
+    undefined | DevicesUnmanagedGetParams,
+    DevicesUnmanagedGetResponse,
+    'device'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/unmanaged/get',
+        method: 'post',
+        data: body,
+      },
+      'device',
+    )
   }
 
-  async list(
+  list(
     body?: DevicesUnmanagedListParams,
-  ): Promise<DevicesUnmanagedListResponse['devices']> {
-    const { data } = await this.client.request<DevicesUnmanagedListResponse>({
-      url: '/devices/unmanaged/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.devices
+  ): SeamApiRequest<
+    undefined | DevicesUnmanagedListParams,
+    DevicesUnmanagedListResponse,
+    'devices'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/unmanaged/list',
+        method: 'post',
+        data: body,
+      },
+      'devices',
+    )
   }
 
-  async update(body?: DevicesUnmanagedUpdateBody): Promise<void> {
-    await this.client.request<DevicesUnmanagedUpdateResponse>({
-      url: '/devices/unmanaged/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: DevicesUnmanagedUpdateBody,
+  ): SeamApiRequest<undefined | DevicesUnmanagedUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/unmanaged/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -164,9 +164,7 @@ export class SeamHttpDevices {
     return SeamHttpDevicesSimulate.fromClient(this.client, this.defaults)
   }
 
-  delete(
-    body?: DevicesDeleteBody,
-  ): SeamHttpRequest<undefined | DevicesDeleteBody, void, undefined> {
+  delete(body?: DevicesDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/devices/delete',
       method: 'post',
@@ -175,13 +173,7 @@ export class SeamHttpDevices {
     })
   }
 
-  get(
-    body?: DevicesGetParams,
-  ): SeamHttpRequest<
-    undefined | DevicesGetParams,
-    DevicesGetResponse,
-    'device'
-  > {
+  get(body?: DevicesGetParams): SeamHttpRequest<DevicesGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
       path: '/devices/get',
       method: 'post',
@@ -192,11 +184,7 @@ export class SeamHttpDevices {
 
   list(
     body?: DevicesListParams,
-  ): SeamHttpRequest<
-    undefined | DevicesListParams,
-    DevicesListResponse,
-    'devices'
-  > {
+  ): SeamHttpRequest<DevicesListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
       path: '/devices/list',
       method: 'post',
@@ -207,11 +195,7 @@ export class SeamHttpDevices {
 
   listDeviceProviders(
     body?: DevicesListDeviceProvidersParams,
-  ): SeamHttpRequest<
-    undefined | DevicesListDeviceProvidersParams,
-    DevicesListDeviceProvidersResponse,
-    'device_providers'
-  > {
+  ): SeamHttpRequest<DevicesListDeviceProvidersResponse, 'device_providers'> {
     return new SeamHttpRequest(this, {
       path: '/devices/list_device_providers',
       method: 'post',
@@ -220,9 +204,7 @@ export class SeamHttpDevices {
     })
   }
 
-  update(
-    body?: DevicesUpdateBody,
-  ): SeamHttpRequest<undefined | DevicesUpdateBody, void, undefined> {
+  update(body?: DevicesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/devices/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -167,15 +167,12 @@ export class SeamHttpDevices {
   delete(
     body?: DevicesDeleteBody,
   ): SeamHttpRequest<undefined | DevicesDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -185,15 +182,12 @@ export class SeamHttpDevices {
     DevicesGetResponse,
     'device'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/get',
-        method: 'post',
-        data: body,
-      },
-      'device',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/get',
+      method: 'post',
+      body,
+      responseKey: 'device',
+    })
   }
 
   list(
@@ -203,15 +197,12 @@ export class SeamHttpDevices {
     DevicesListResponse,
     'devices'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/list',
-        method: 'post',
-        data: body,
-      },
-      'devices',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/list',
+      method: 'post',
+      body,
+      responseKey: 'devices',
+    })
   }
 
   listDeviceProviders(
@@ -221,29 +212,23 @@ export class SeamHttpDevices {
     DevicesListDeviceProvidersResponse,
     'device_providers'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/list_device_providers',
-        method: 'post',
-        data: body,
-      },
-      'device_providers',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/list_device_providers',
+      method: 'post',
+      body,
+      responseKey: 'device_providers',
+    })
   }
 
   update(
     body?: DevicesUpdateBody,
   ): SeamHttpRequest<undefined | DevicesUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/devices/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/devices/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpDevicesSimulate } from './devices-simulate.js'
@@ -163,55 +164,86 @@ export class SeamHttpDevices {
     return SeamHttpDevicesSimulate.fromClient(this.client, this.defaults)
   }
 
-  async delete(body?: DevicesDeleteBody): Promise<void> {
-    await this.client.request<DevicesDeleteResponse>({
-      url: '/devices/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: DevicesDeleteBody,
+  ): SeamApiRequest<undefined | DevicesDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(body?: DevicesGetParams): Promise<DevicesGetResponse['device']> {
-    const { data } = await this.client.request<DevicesGetResponse>({
-      url: '/devices/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.device
+  get(
+    body?: DevicesGetParams,
+  ): SeamApiRequest<
+    undefined | DevicesGetParams,
+    DevicesGetResponse,
+    'device'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/get',
+        method: 'post',
+        data: body,
+      },
+      'device',
+    )
   }
 
-  async list(
+  list(
     body?: DevicesListParams,
-  ): Promise<DevicesListResponse['devices']> {
-    const { data } = await this.client.request<DevicesListResponse>({
-      url: '/devices/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.devices
+  ): SeamApiRequest<
+    undefined | DevicesListParams,
+    DevicesListResponse,
+    'devices'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/list',
+        method: 'post',
+        data: body,
+      },
+      'devices',
+    )
   }
 
-  async listDeviceProviders(
+  listDeviceProviders(
     body?: DevicesListDeviceProvidersParams,
-  ): Promise<DevicesListDeviceProvidersResponse['device_providers']> {
-    const { data } =
-      await this.client.request<DevicesListDeviceProvidersResponse>({
+  ): SeamApiRequest<
+    undefined | DevicesListDeviceProvidersParams,
+    DevicesListDeviceProvidersResponse,
+    'device_providers'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/devices/list_device_providers',
         method: 'post',
         data: body,
-      })
-
-    return data.device_providers
+      },
+      'device_providers',
+    )
   }
 
-  async update(body?: DevicesUpdateBody): Promise<void> {
-    await this.client.request<DevicesUpdateResponse>({
-      url: '/devices/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: DevicesUpdateBody,
+  ): SeamApiRequest<undefined | DevicesUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/devices/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpDevicesSimulate } from './devices-simulate.js'
@@ -166,8 +166,8 @@ export class SeamHttpDevices {
 
   delete(
     body?: DevicesDeleteBody,
-  ): SeamApiRequest<undefined | DevicesDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | DevicesDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/delete',
@@ -180,12 +180,12 @@ export class SeamHttpDevices {
 
   get(
     body?: DevicesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | DevicesGetParams,
     DevicesGetResponse,
     'device'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/get',
@@ -198,12 +198,12 @@ export class SeamHttpDevices {
 
   list(
     body?: DevicesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | DevicesListParams,
     DevicesListResponse,
     'devices'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/list',
@@ -216,12 +216,12 @@ export class SeamHttpDevices {
 
   listDeviceProviders(
     body?: DevicesListDeviceProvidersParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | DevicesListDeviceProvidersParams,
     DevicesListDeviceProvidersResponse,
     'device_providers'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/list_device_providers',
@@ -234,8 +234,8 @@ export class SeamHttpDevices {
 
   update(
     body?: DevicesUpdateBody,
-  ): SeamApiRequest<undefined | DevicesUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | DevicesUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/devices/update',

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -157,15 +157,12 @@ export class SeamHttpEvents {
   get(
     body?: EventsGetParams,
   ): SeamHttpRequest<undefined | EventsGetParams, EventsGetResponse, 'event'> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/events/get',
-        method: 'post',
-        data: body,
-      },
-      'event',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/events/get',
+      method: 'post',
+      body,
+      responseKey: 'event',
+    })
   }
 
   list(
@@ -175,15 +172,12 @@ export class SeamHttpEvents {
     EventsListResponse,
     'events'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/events/list',
-        method: 'post',
-        data: body,
-      },
-      'events',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/events/list',
+      method: 'post',
+      body,
+      responseKey: 'events',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -154,9 +154,7 @@ export class SeamHttpEvents {
     await clientSessions.get()
   }
 
-  get(
-    body?: EventsGetParams,
-  ): SeamHttpRequest<undefined | EventsGetParams, EventsGetResponse, 'event'> {
+  get(body?: EventsGetParams): SeamHttpRequest<EventsGetResponse, 'event'> {
     return new SeamHttpRequest(this, {
       path: '/events/get',
       method: 'post',
@@ -165,13 +163,7 @@ export class SeamHttpEvents {
     })
   }
 
-  list(
-    body?: EventsListParams,
-  ): SeamHttpRequest<
-    undefined | EventsListParams,
-    EventsListResponse,
-    'events'
-  > {
+  list(body?: EventsListParams): SeamHttpRequest<EventsListResponse, 'events'> {
     return new SeamHttpRequest(this, {
       path: '/events/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,24 +154,36 @@ export class SeamHttpEvents {
     await clientSessions.get()
   }
 
-  async get(body?: EventsGetParams): Promise<EventsGetResponse['event']> {
-    const { data } = await this.client.request<EventsGetResponse>({
-      url: '/events/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.event
+  get(
+    body?: EventsGetParams,
+  ): SeamApiRequest<undefined | EventsGetParams, EventsGetResponse, 'event'> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/events/get',
+        method: 'post',
+        data: body,
+      },
+      'event',
+    )
   }
 
-  async list(body?: EventsListParams): Promise<EventsListResponse['events']> {
-    const { data } = await this.client.request<EventsListResponse>({
-      url: '/events/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.events
+  list(
+    body?: EventsListParams,
+  ): SeamApiRequest<
+    undefined | EventsListParams,
+    EventsListResponse,
+    'events'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/events/list',
+        method: 'post',
+        data: body,
+      },
+      'events',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,8 @@ export class SeamHttpEvents {
 
   get(
     body?: EventsGetParams,
-  ): SeamApiRequest<undefined | EventsGetParams, EventsGetResponse, 'event'> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | EventsGetParams, EventsGetResponse, 'event'> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/events/get',
@@ -170,12 +170,12 @@ export class SeamHttpEvents {
 
   list(
     body?: EventsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | EventsListParams,
     EventsListResponse,
     'events'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/events/list',

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -31,9 +31,8 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { resolveActionAttempt } from 'lib/seam/connect/resolve-action-attempt.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
-import { SeamHttpActionAttempts } from './action-attempts.js'
 import { SeamHttpClientSessions } from './client-sessions.js'
 
 export class SeamHttpLocks {
@@ -155,72 +154,72 @@ export class SeamHttpLocks {
     await clientSessions.get()
   }
 
-  async get(body?: LocksGetParams): Promise<LocksGetResponse['device']> {
-    const { data } = await this.client.request<LocksGetResponse>({
-      url: '/locks/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.device
+  get(
+    body?: LocksGetParams,
+  ): SeamApiRequest<undefined | LocksGetParams, LocksGetResponse, 'device'> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/locks/get',
+        method: 'post',
+        data: body,
+      },
+      'device',
+    )
   }
 
-  async list(body?: LocksListParams): Promise<LocksListResponse['devices']> {
-    const { data } = await this.client.request<LocksListResponse>({
-      url: '/locks/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.devices
+  list(
+    body?: LocksListParams,
+  ): SeamApiRequest<undefined | LocksListParams, LocksListResponse, 'devices'> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/locks/list',
+        method: 'post',
+        data: body,
+      },
+      'devices',
+    )
   }
 
-  async lockDoor(
+  lockDoor(
     body?: LocksLockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<LocksLockDoorResponse['action_attempt']> {
-    const { data } = await this.client.request<LocksLockDoorResponse>({
-      url: '/locks/lock_door',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | LocksLockDoorBody,
+    LocksLockDoorResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/locks/lock_door',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async unlockDoor(
+  unlockDoor(
     body?: LocksUnlockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<LocksUnlockDoorResponse['action_attempt']> {
-    const { data } = await this.client.request<LocksUnlockDoorResponse>({
-      url: '/locks/unlock_door',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | LocksUnlockDoorBody,
+    LocksUnlockDoorResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/locks/unlock_door',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,8 +156,8 @@ export class SeamHttpLocks {
 
   get(
     body?: LocksGetParams,
-  ): SeamApiRequest<undefined | LocksGetParams, LocksGetResponse, 'device'> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | LocksGetParams, LocksGetResponse, 'device'> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/locks/get',
@@ -170,8 +170,12 @@ export class SeamHttpLocks {
 
   list(
     body?: LocksListParams,
-  ): SeamApiRequest<undefined | LocksListParams, LocksListResponse, 'devices'> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<
+    undefined | LocksListParams,
+    LocksListResponse,
+    'devices'
+  > {
+    return new SeamHttpRequest(
       this,
       {
         url: '/locks/list',
@@ -185,12 +189,12 @@ export class SeamHttpLocks {
   lockDoor(
     body?: LocksLockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | LocksLockDoorBody,
     LocksLockDoorResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/locks/lock_door',
@@ -205,12 +209,12 @@ export class SeamHttpLocks {
   unlockDoor(
     body?: LocksUnlockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | LocksUnlockDoorBody,
     LocksUnlockDoorResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/locks/unlock_door',

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -157,15 +157,12 @@ export class SeamHttpLocks {
   get(
     body?: LocksGetParams,
   ): SeamHttpRequest<undefined | LocksGetParams, LocksGetResponse, 'device'> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/locks/get',
-        method: 'post',
-        data: body,
-      },
-      'device',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/locks/get',
+      method: 'post',
+      body,
+      responseKey: 'device',
+    })
   }
 
   list(
@@ -175,15 +172,12 @@ export class SeamHttpLocks {
     LocksListResponse,
     'devices'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/locks/list',
-        method: 'post',
-        data: body,
-      },
-      'devices',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/locks/list',
+      method: 'post',
+      body,
+      responseKey: 'devices',
+    })
   }
 
   lockDoor(
@@ -194,16 +188,13 @@ export class SeamHttpLocks {
     LocksLockDoorResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/locks/lock_door',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/locks/lock_door',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   unlockDoor(
@@ -214,16 +205,13 @@ export class SeamHttpLocks {
     LocksUnlockDoorResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/locks/unlock_door',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/locks/unlock_door',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -154,9 +154,7 @@ export class SeamHttpLocks {
     await clientSessions.get()
   }
 
-  get(
-    body?: LocksGetParams,
-  ): SeamHttpRequest<undefined | LocksGetParams, LocksGetResponse, 'device'> {
+  get(body?: LocksGetParams): SeamHttpRequest<LocksGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
       path: '/locks/get',
       method: 'post',
@@ -165,13 +163,7 @@ export class SeamHttpLocks {
     })
   }
 
-  list(
-    body?: LocksListParams,
-  ): SeamHttpRequest<
-    undefined | LocksListParams,
-    LocksListResponse,
-    'devices'
-  > {
+  list(body?: LocksListParams): SeamHttpRequest<LocksListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
       path: '/locks/list',
       method: 'post',
@@ -183,11 +175,7 @@ export class SeamHttpLocks {
   lockDoor(
     body?: LocksLockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | LocksLockDoorBody,
-    LocksLockDoorResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<LocksLockDoorResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/locks/lock_door',
       method: 'post',
@@ -200,11 +188,7 @@ export class SeamHttpLocks {
   unlockDoor(
     body?: LocksUnlockDoorBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | LocksUnlockDoorBody,
-    LocksUnlockDoorResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<LocksUnlockDoorResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/locks/unlock_door',
       method: 'post',

--- a/src/lib/seam/connect/routes/networks.ts
+++ b/src/lib/seam/connect/routes/networks.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,26 +154,40 @@ export class SeamHttpNetworks {
     await clientSessions.get()
   }
 
-  async get(body?: NetworksGetParams): Promise<NetworksGetResponse['network']> {
-    const { data } = await this.client.request<NetworksGetResponse>({
-      url: '/networks/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.network
+  get(
+    body?: NetworksGetParams,
+  ): SeamApiRequest<
+    undefined | NetworksGetParams,
+    NetworksGetResponse,
+    'network'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/networks/get',
+        method: 'post',
+        data: body,
+      },
+      'network',
+    )
   }
 
-  async list(
+  list(
     body?: NetworksListParams,
-  ): Promise<NetworksListResponse['networks']> {
-    const { data } = await this.client.request<NetworksListResponse>({
-      url: '/networks/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.networks
+  ): SeamApiRequest<
+    undefined | NetworksListParams,
+    NetworksListResponse,
+    'networks'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/networks/list',
+        method: 'post',
+        data: body,
+      },
+      'networks',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/networks.ts
+++ b/src/lib/seam/connect/routes/networks.ts
@@ -156,11 +156,7 @@ export class SeamHttpNetworks {
 
   get(
     body?: NetworksGetParams,
-  ): SeamHttpRequest<
-    undefined | NetworksGetParams,
-    NetworksGetResponse,
-    'network'
-  > {
+  ): SeamHttpRequest<NetworksGetResponse, 'network'> {
     return new SeamHttpRequest(this, {
       path: '/networks/get',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpNetworks {
 
   list(
     body?: NetworksListParams,
-  ): SeamHttpRequest<
-    undefined | NetworksListParams,
-    NetworksListResponse,
-    'networks'
-  > {
+  ): SeamHttpRequest<NetworksListResponse, 'networks'> {
     return new SeamHttpRequest(this, {
       path: '/networks/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/networks.ts
+++ b/src/lib/seam/connect/routes/networks.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpNetworks {
 
   get(
     body?: NetworksGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NetworksGetParams,
     NetworksGetResponse,
     'network'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/networks/get',
@@ -174,12 +174,12 @@ export class SeamHttpNetworks {
 
   list(
     body?: NetworksListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NetworksListParams,
     NetworksListResponse,
     'networks'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/networks/list',

--- a/src/lib/seam/connect/routes/networks.ts
+++ b/src/lib/seam/connect/routes/networks.ts
@@ -161,15 +161,12 @@ export class SeamHttpNetworks {
     NetworksGetResponse,
     'network'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/networks/get',
-        method: 'post',
-        data: body,
-      },
-      'network',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/networks/get',
+      method: 'post',
+      body,
+      responseKey: 'network',
+    })
   }
 
   list(
@@ -179,15 +176,12 @@ export class SeamHttpNetworks {
     NetworksListResponse,
     'networks'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/networks/list',
-        method: 'post',
-        data: body,
-      },
-      'networks',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/networks/list',
+      method: 'post',
+      body,
+      responseKey: 'networks',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,59 +157,94 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: NoiseSensorsNoiseThresholdsCreateBody,
-  ): Promise<NoiseSensorsNoiseThresholdsCreateResponse['noise_threshold']> {
-    const { data } =
-      await this.client.request<NoiseSensorsNoiseThresholdsCreateResponse>({
+  ): SeamApiRequest<
+    undefined | NoiseSensorsNoiseThresholdsCreateBody,
+    NoiseSensorsNoiseThresholdsCreateResponse,
+    'noise_threshold'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/noise_sensors/noise_thresholds/create',
         method: 'post',
         data: body,
-      })
-
-    return data.noise_threshold
+      },
+      'noise_threshold',
+    )
   }
 
-  async delete(body?: NoiseSensorsNoiseThresholdsDeleteBody): Promise<void> {
-    await this.client.request<NoiseSensorsNoiseThresholdsDeleteResponse>({
-      url: '/noise_sensors/noise_thresholds/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: NoiseSensorsNoiseThresholdsDeleteBody,
+  ): SeamApiRequest<
+    undefined | NoiseSensorsNoiseThresholdsDeleteBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/noise_sensors/noise_thresholds/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(
+  get(
     body?: NoiseSensorsNoiseThresholdsGetParams,
-  ): Promise<NoiseSensorsNoiseThresholdsGetResponse['noise_threshold']> {
-    const { data } =
-      await this.client.request<NoiseSensorsNoiseThresholdsGetResponse>({
+  ): SeamApiRequest<
+    undefined | NoiseSensorsNoiseThresholdsGetParams,
+    NoiseSensorsNoiseThresholdsGetResponse,
+    'noise_threshold'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/noise_sensors/noise_thresholds/get',
         method: 'post',
         data: body,
-      })
-
-    return data.noise_threshold
+      },
+      'noise_threshold',
+    )
   }
 
-  async list(
+  list(
     body?: NoiseSensorsNoiseThresholdsListParams,
-  ): Promise<NoiseSensorsNoiseThresholdsListResponse['noise_thresholds']> {
-    const { data } =
-      await this.client.request<NoiseSensorsNoiseThresholdsListResponse>({
+  ): SeamApiRequest<
+    undefined | NoiseSensorsNoiseThresholdsListParams,
+    NoiseSensorsNoiseThresholdsListResponse,
+    'noise_thresholds'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/noise_sensors/noise_thresholds/list',
         method: 'post',
         data: body,
-      })
-
-    return data.noise_thresholds
+      },
+      'noise_thresholds',
+    )
   }
 
-  async update(body?: NoiseSensorsNoiseThresholdsUpdateBody): Promise<void> {
-    await this.client.request<NoiseSensorsNoiseThresholdsUpdateResponse>({
-      url: '/noise_sensors/noise_thresholds/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: NoiseSensorsNoiseThresholdsUpdateBody,
+  ): SeamApiRequest<
+    undefined | NoiseSensorsNoiseThresholdsUpdateBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/noise_sensors/noise_thresholds/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -160,7 +160,6 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   create(
     body?: NoiseSensorsNoiseThresholdsCreateBody,
   ): SeamHttpRequest<
-    undefined | NoiseSensorsNoiseThresholdsCreateBody,
     NoiseSensorsNoiseThresholdsCreateResponse,
     'noise_threshold'
   > {
@@ -174,11 +173,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   delete(
     body?: NoiseSensorsNoiseThresholdsDeleteBody,
-  ): SeamHttpRequest<
-    undefined | NoiseSensorsNoiseThresholdsDeleteBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/noise_sensors/noise_thresholds/delete',
       method: 'post',
@@ -190,7 +185,6 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   get(
     body?: NoiseSensorsNoiseThresholdsGetParams,
   ): SeamHttpRequest<
-    undefined | NoiseSensorsNoiseThresholdsGetParams,
     NoiseSensorsNoiseThresholdsGetResponse,
     'noise_threshold'
   > {
@@ -205,7 +199,6 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   list(
     body?: NoiseSensorsNoiseThresholdsListParams,
   ): SeamHttpRequest<
-    undefined | NoiseSensorsNoiseThresholdsListParams,
     NoiseSensorsNoiseThresholdsListResponse,
     'noise_thresholds'
   > {
@@ -219,11 +212,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   update(
     body?: NoiseSensorsNoiseThresholdsUpdateBody,
-  ): SeamHttpRequest<
-    undefined | NoiseSensorsNoiseThresholdsUpdateBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/noise_sensors/noise_thresholds/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -164,15 +164,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     NoiseSensorsNoiseThresholdsCreateResponse,
     'noise_threshold'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/noise_sensors/noise_thresholds/create',
-        method: 'post',
-        data: body,
-      },
-      'noise_threshold',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/noise_sensors/noise_thresholds/create',
+      method: 'post',
+      body,
+      responseKey: 'noise_threshold',
+    })
   }
 
   delete(
@@ -182,15 +179,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/noise_sensors/noise_thresholds/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/noise_sensors/noise_thresholds/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -200,15 +194,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     NoiseSensorsNoiseThresholdsGetResponse,
     'noise_threshold'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/noise_sensors/noise_thresholds/get',
-        method: 'post',
-        data: body,
-      },
-      'noise_threshold',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/noise_sensors/noise_thresholds/get',
+      method: 'post',
+      body,
+      responseKey: 'noise_threshold',
+    })
   }
 
   list(
@@ -218,15 +209,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     NoiseSensorsNoiseThresholdsListResponse,
     'noise_thresholds'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/noise_sensors/noise_thresholds/list',
-        method: 'post',
-        data: body,
-      },
-      'noise_thresholds',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/noise_sensors/noise_thresholds/list',
+      method: 'post',
+      body,
+      responseKey: 'noise_thresholds',
+    })
   }
 
   update(
@@ -236,15 +224,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/noise_sensors/noise_thresholds/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/noise_sensors/noise_thresholds/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -159,12 +159,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   create(
     body?: NoiseSensorsNoiseThresholdsCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NoiseSensorsNoiseThresholdsCreateBody,
     NoiseSensorsNoiseThresholdsCreateResponse,
     'noise_threshold'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/noise_sensors/noise_thresholds/create',
@@ -177,12 +177,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   delete(
     body?: NoiseSensorsNoiseThresholdsDeleteBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NoiseSensorsNoiseThresholdsDeleteBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/noise_sensors/noise_thresholds/delete',
@@ -195,12 +195,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   get(
     body?: NoiseSensorsNoiseThresholdsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NoiseSensorsNoiseThresholdsGetParams,
     NoiseSensorsNoiseThresholdsGetResponse,
     'noise_threshold'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/noise_sensors/noise_thresholds/get',
@@ -213,12 +213,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   list(
     body?: NoiseSensorsNoiseThresholdsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NoiseSensorsNoiseThresholdsListParams,
     NoiseSensorsNoiseThresholdsListResponse,
     'noise_thresholds'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/noise_sensors/noise_thresholds/list',
@@ -231,12 +231,12 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
 
   update(
     body?: NoiseSensorsNoiseThresholdsUpdateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | NoiseSensorsNoiseThresholdsUpdateBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/noise_sensors/noise_thresholds/update',

--- a/src/lib/seam/connect/routes/phones-simulate.ts
+++ b/src/lib/seam/connect/routes/phones-simulate.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpPhonesSimulate {
 
   createSandboxPhone(
     body?: PhonesSimulateCreateSandboxPhoneBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | PhonesSimulateCreateSandboxPhoneBody,
     PhonesSimulateCreateSandboxPhoneResponse,
     'phone'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/phones/simulate/create_sandbox_phone',

--- a/src/lib/seam/connect/routes/phones-simulate.ts
+++ b/src/lib/seam/connect/routes/phones-simulate.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,17 +154,22 @@ export class SeamHttpPhonesSimulate {
     await clientSessions.get()
   }
 
-  async createSandboxPhone(
+  createSandboxPhone(
     body?: PhonesSimulateCreateSandboxPhoneBody,
-  ): Promise<PhonesSimulateCreateSandboxPhoneResponse['phone']> {
-    const { data } =
-      await this.client.request<PhonesSimulateCreateSandboxPhoneResponse>({
+  ): SeamApiRequest<
+    undefined | PhonesSimulateCreateSandboxPhoneBody,
+    PhonesSimulateCreateSandboxPhoneResponse,
+    'phone'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/phones/simulate/create_sandbox_phone',
         method: 'post',
         data: body,
-      })
-
-    return data.phone
+      },
+      'phone',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/phones-simulate.ts
+++ b/src/lib/seam/connect/routes/phones-simulate.ts
@@ -156,11 +156,7 @@ export class SeamHttpPhonesSimulate {
 
   createSandboxPhone(
     body?: PhonesSimulateCreateSandboxPhoneBody,
-  ): SeamHttpRequest<
-    undefined | PhonesSimulateCreateSandboxPhoneBody,
-    PhonesSimulateCreateSandboxPhoneResponse,
-    'phone'
-  > {
+  ): SeamHttpRequest<PhonesSimulateCreateSandboxPhoneResponse, 'phone'> {
     return new SeamHttpRequest(this, {
       path: '/phones/simulate/create_sandbox_phone',
       method: 'post',

--- a/src/lib/seam/connect/routes/phones-simulate.ts
+++ b/src/lib/seam/connect/routes/phones-simulate.ts
@@ -161,15 +161,12 @@ export class SeamHttpPhonesSimulate {
     PhonesSimulateCreateSandboxPhoneResponse,
     'phone'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/phones/simulate/create_sandbox_phone',
-        method: 'post',
-        data: body,
-      },
-      'phone',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/phones/simulate/create_sandbox_phone',
+      method: 'post',
+      body,
+      responseKey: 'phone',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/phones.ts
+++ b/src/lib/seam/connect/routes/phones.ts
@@ -162,15 +162,12 @@ export class SeamHttpPhones {
   deactivate(
     body?: PhonesDeactivateBody,
   ): SeamHttpRequest<undefined | PhonesDeactivateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/phones/deactivate',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/phones/deactivate',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   list(
@@ -180,15 +177,12 @@ export class SeamHttpPhones {
     PhonesListResponse,
     'phones'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/phones/list',
-        method: 'post',
-        data: body,
-      },
-      'phones',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/phones/list',
+      method: 'post',
+      body,
+      responseKey: 'phones',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/phones.ts
+++ b/src/lib/seam/connect/routes/phones.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpPhonesSimulate } from './phones-simulate.js'
@@ -158,22 +159,36 @@ export class SeamHttpPhones {
     return SeamHttpPhonesSimulate.fromClient(this.client, this.defaults)
   }
 
-  async deactivate(body?: PhonesDeactivateBody): Promise<void> {
-    await this.client.request<PhonesDeactivateResponse>({
-      url: '/phones/deactivate',
-      method: 'post',
-      data: body,
-    })
+  deactivate(
+    body?: PhonesDeactivateBody,
+  ): SeamApiRequest<undefined | PhonesDeactivateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/phones/deactivate',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async list(body?: PhonesListParams): Promise<PhonesListResponse['phones']> {
-    const { data } = await this.client.request<PhonesListResponse>({
-      url: '/phones/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.phones
+  list(
+    body?: PhonesListParams,
+  ): SeamApiRequest<
+    undefined | PhonesListParams,
+    PhonesListResponse,
+    'phones'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/phones/list',
+        method: 'post',
+        data: body,
+      },
+      'phones',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/phones.ts
+++ b/src/lib/seam/connect/routes/phones.ts
@@ -159,9 +159,7 @@ export class SeamHttpPhones {
     return SeamHttpPhonesSimulate.fromClient(this.client, this.defaults)
   }
 
-  deactivate(
-    body?: PhonesDeactivateBody,
-  ): SeamHttpRequest<undefined | PhonesDeactivateBody, void, undefined> {
+  deactivate(body?: PhonesDeactivateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/phones/deactivate',
       method: 'post',
@@ -170,13 +168,7 @@ export class SeamHttpPhones {
     })
   }
 
-  list(
-    body?: PhonesListParams,
-  ): SeamHttpRequest<
-    undefined | PhonesListParams,
-    PhonesListResponse,
-    'phones'
-  > {
+  list(body?: PhonesListParams): SeamHttpRequest<PhonesListResponse, 'phones'> {
     return new SeamHttpRequest(this, {
       path: '/phones/list',
       method: 'post',

--- a/src/lib/seam/connect/routes/phones.ts
+++ b/src/lib/seam/connect/routes/phones.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpPhonesSimulate } from './phones-simulate.js'
@@ -161,8 +161,8 @@ export class SeamHttpPhones {
 
   deactivate(
     body?: PhonesDeactivateBody,
-  ): SeamApiRequest<undefined | PhonesDeactivateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | PhonesDeactivateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/phones/deactivate',
@@ -175,12 +175,12 @@ export class SeamHttpPhones {
 
   list(
     body?: PhonesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | PhonesListParams,
     PhonesListResponse,
     'phones'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/phones/list',

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -160,7 +160,6 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   create(
     body?: ThermostatsClimateSettingSchedulesCreateBody,
   ): SeamHttpRequest<
-    undefined | ThermostatsClimateSettingSchedulesCreateBody,
     ThermostatsClimateSettingSchedulesCreateResponse,
     'climate_setting_schedule'
   > {
@@ -174,11 +173,7 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   delete(
     body?: ThermostatsClimateSettingSchedulesDeleteBody,
-  ): SeamHttpRequest<
-    undefined | ThermostatsClimateSettingSchedulesDeleteBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/climate_setting_schedules/delete',
       method: 'post',
@@ -190,7 +185,6 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   get(
     body?: ThermostatsClimateSettingSchedulesGetParams,
   ): SeamHttpRequest<
-    undefined | ThermostatsClimateSettingSchedulesGetParams,
     ThermostatsClimateSettingSchedulesGetResponse,
     'climate_setting_schedule'
   > {
@@ -205,7 +199,6 @@ export class SeamHttpThermostatsClimateSettingSchedules {
   list(
     body?: ThermostatsClimateSettingSchedulesListParams,
   ): SeamHttpRequest<
-    undefined | ThermostatsClimateSettingSchedulesListParams,
     ThermostatsClimateSettingSchedulesListResponse,
     'climate_setting_schedules'
   > {
@@ -219,11 +212,7 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   update(
     body?: ThermostatsClimateSettingSchedulesUpdateBody,
-  ): SeamHttpRequest<
-    undefined | ThermostatsClimateSettingSchedulesUpdateBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/climate_setting_schedules/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,76 +157,93 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: ThermostatsClimateSettingSchedulesCreateBody,
-  ): Promise<
-    ThermostatsClimateSettingSchedulesCreateResponse['climate_setting_schedule']
+  ): SeamApiRequest<
+    undefined | ThermostatsClimateSettingSchedulesCreateBody,
+    ThermostatsClimateSettingSchedulesCreateResponse,
+    'climate_setting_schedule'
   > {
-    const { data } =
-      await this.client.request<ThermostatsClimateSettingSchedulesCreateResponse>(
-        {
-          url: '/thermostats/climate_setting_schedules/create',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.climate_setting_schedule
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/climate_setting_schedules/create',
+        method: 'post',
+        data: body,
+      },
+      'climate_setting_schedule',
+    )
   }
 
-  async delete(
+  delete(
     body?: ThermostatsClimateSettingSchedulesDeleteBody,
-  ): Promise<void> {
-    await this.client.request<ThermostatsClimateSettingSchedulesDeleteResponse>(
+  ): SeamApiRequest<
+    undefined | ThermostatsClimateSettingSchedulesDeleteBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/thermostats/climate_setting_schedules/delete',
         method: 'post',
         data: body,
       },
+      undefined,
     )
   }
 
-  async get(
+  get(
     body?: ThermostatsClimateSettingSchedulesGetParams,
-  ): Promise<
-    ThermostatsClimateSettingSchedulesGetResponse['climate_setting_schedule']
+  ): SeamApiRequest<
+    undefined | ThermostatsClimateSettingSchedulesGetParams,
+    ThermostatsClimateSettingSchedulesGetResponse,
+    'climate_setting_schedule'
   > {
-    const { data } =
-      await this.client.request<ThermostatsClimateSettingSchedulesGetResponse>({
+    return new SeamApiRequest(
+      this,
+      {
         url: '/thermostats/climate_setting_schedules/get',
         method: 'post',
         data: body,
-      })
-
-    return data.climate_setting_schedule
+      },
+      'climate_setting_schedule',
+    )
   }
 
-  async list(
+  list(
     body?: ThermostatsClimateSettingSchedulesListParams,
-  ): Promise<
-    ThermostatsClimateSettingSchedulesListResponse['climate_setting_schedules']
+  ): SeamApiRequest<
+    undefined | ThermostatsClimateSettingSchedulesListParams,
+    ThermostatsClimateSettingSchedulesListResponse,
+    'climate_setting_schedules'
   > {
-    const { data } =
-      await this.client.request<ThermostatsClimateSettingSchedulesListResponse>(
-        {
-          url: '/thermostats/climate_setting_schedules/list',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.climate_setting_schedules
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/climate_setting_schedules/list',
+        method: 'post',
+        data: body,
+      },
+      'climate_setting_schedules',
+    )
   }
 
-  async update(
+  update(
     body?: ThermostatsClimateSettingSchedulesUpdateBody,
-  ): Promise<void> {
-    await this.client.request<ThermostatsClimateSettingSchedulesUpdateResponse>(
+  ): SeamApiRequest<
+    undefined | ThermostatsClimateSettingSchedulesUpdateBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/thermostats/climate_setting_schedules/update',
         method: 'post',
         data: body,
       },
+      undefined,
     )
   }
 }

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -164,15 +164,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     ThermostatsClimateSettingSchedulesCreateResponse,
     'climate_setting_schedule'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/climate_setting_schedules/create',
-        method: 'post',
-        data: body,
-      },
-      'climate_setting_schedule',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/climate_setting_schedules/create',
+      method: 'post',
+      body,
+      responseKey: 'climate_setting_schedule',
+    })
   }
 
   delete(
@@ -182,15 +179,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/climate_setting_schedules/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/climate_setting_schedules/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -200,15 +194,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     ThermostatsClimateSettingSchedulesGetResponse,
     'climate_setting_schedule'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/climate_setting_schedules/get',
-        method: 'post',
-        data: body,
-      },
-      'climate_setting_schedule',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/climate_setting_schedules/get',
+      method: 'post',
+      body,
+      responseKey: 'climate_setting_schedule',
+    })
   }
 
   list(
@@ -218,15 +209,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     ThermostatsClimateSettingSchedulesListResponse,
     'climate_setting_schedules'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/climate_setting_schedules/list',
-        method: 'post',
-        data: body,
-      },
-      'climate_setting_schedules',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/climate_setting_schedules/list',
+      method: 'post',
+      body,
+      responseKey: 'climate_setting_schedules',
+    })
   }
 
   update(
@@ -236,15 +224,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/climate_setting_schedules/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/climate_setting_schedules/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-climate-setting-schedules.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -159,12 +159,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   create(
     body?: ThermostatsClimateSettingSchedulesCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsClimateSettingSchedulesCreateBody,
     ThermostatsClimateSettingSchedulesCreateResponse,
     'climate_setting_schedule'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/climate_setting_schedules/create',
@@ -177,12 +177,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   delete(
     body?: ThermostatsClimateSettingSchedulesDeleteBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsClimateSettingSchedulesDeleteBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/climate_setting_schedules/delete',
@@ -195,12 +195,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   get(
     body?: ThermostatsClimateSettingSchedulesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsClimateSettingSchedulesGetParams,
     ThermostatsClimateSettingSchedulesGetResponse,
     'climate_setting_schedule'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/climate_setting_schedules/get',
@@ -213,12 +213,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   list(
     body?: ThermostatsClimateSettingSchedulesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsClimateSettingSchedulesListParams,
     ThermostatsClimateSettingSchedulesListResponse,
     'climate_setting_schedules'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/climate_setting_schedules/list',
@@ -231,12 +231,12 @@ export class SeamHttpThermostatsClimateSettingSchedules {
 
   update(
     body?: ThermostatsClimateSettingSchedulesUpdateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsClimateSettingSchedulesUpdateBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/climate_setting_schedules/update',

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -170,16 +170,13 @@ export class SeamHttpThermostats {
     ThermostatsCoolResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/cool',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/cool',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   get(
@@ -189,15 +186,12 @@ export class SeamHttpThermostats {
     ThermostatsGetResponse,
     'thermostat'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/get',
-        method: 'post',
-        data: body,
-      },
-      'thermostat',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/get',
+      method: 'post',
+      body,
+      responseKey: 'thermostat',
+    })
   }
 
   heat(
@@ -208,16 +202,13 @@ export class SeamHttpThermostats {
     ThermostatsHeatResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/heat',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/heat',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   heatCool(
@@ -228,16 +219,13 @@ export class SeamHttpThermostats {
     ThermostatsHeatCoolResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/heat_cool',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/heat_cool',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   list(
@@ -247,15 +235,12 @@ export class SeamHttpThermostats {
     ThermostatsListResponse,
     'thermostats'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/list',
-        method: 'post',
-        data: body,
-      },
-      'thermostats',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/list',
+      method: 'post',
+      body,
+      responseKey: 'thermostats',
+    })
   }
 
   off(
@@ -266,16 +251,13 @@ export class SeamHttpThermostats {
     ThermostatsOffResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/off',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/off',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   setFanMode(
@@ -286,30 +268,24 @@ export class SeamHttpThermostats {
     ThermostatsSetFanModeResponse,
     'action_attempt'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/set_fan_mode',
-        method: 'post',
-        data: body,
-      },
-      'action_attempt',
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/set_fan_mode',
+      method: 'post',
+      body,
+      responseKey: 'action_attempt',
       options,
-    )
+    })
   }
 
   update(
     body?: ThermostatsUpdateBody,
   ): SeamHttpRequest<undefined | ThermostatsUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/thermostats/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/thermostats/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -31,9 +31,8 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { resolveActionAttempt } from 'lib/seam/connect/resolve-action-attempt.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
-import { SeamHttpActionAttempts } from './action-attempts.js'
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpThermostatsClimateSettingSchedules } from './thermostats-climate-setting-schedules.js'
 
@@ -163,156 +162,154 @@ export class SeamHttpThermostats {
     )
   }
 
-  async cool(
+  cool(
     body?: ThermostatsCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ThermostatsCoolResponse['action_attempt']> {
-    const { data } = await this.client.request<ThermostatsCoolResponse>({
-      url: '/thermostats/cool',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ThermostatsCoolBody,
+    ThermostatsCoolResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/cool',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async get(
+  get(
     body?: ThermostatsGetParams,
-  ): Promise<ThermostatsGetResponse['thermostat']> {
-    const { data } = await this.client.request<ThermostatsGetResponse>({
-      url: '/thermostats/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.thermostat
+  ): SeamApiRequest<
+    undefined | ThermostatsGetParams,
+    ThermostatsGetResponse,
+    'thermostat'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/get',
+        method: 'post',
+        data: body,
+      },
+      'thermostat',
+    )
   }
 
-  async heat(
+  heat(
     body?: ThermostatsHeatBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ThermostatsHeatResponse['action_attempt']> {
-    const { data } = await this.client.request<ThermostatsHeatResponse>({
-      url: '/thermostats/heat',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ThermostatsHeatBody,
+    ThermostatsHeatResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/heat',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async heatCool(
+  heatCool(
     body?: ThermostatsHeatCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ThermostatsHeatCoolResponse['action_attempt']> {
-    const { data } = await this.client.request<ThermostatsHeatCoolResponse>({
-      url: '/thermostats/heat_cool',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ThermostatsHeatCoolBody,
+    ThermostatsHeatCoolResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/heat_cool',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async list(
+  list(
     body?: ThermostatsListParams,
-  ): Promise<ThermostatsListResponse['thermostats']> {
-    const { data } = await this.client.request<ThermostatsListResponse>({
-      url: '/thermostats/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.thermostats
+  ): SeamApiRequest<
+    undefined | ThermostatsListParams,
+    ThermostatsListResponse,
+    'thermostats'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/list',
+        method: 'post',
+        data: body,
+      },
+      'thermostats',
+    )
   }
 
-  async off(
+  off(
     body?: ThermostatsOffBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ThermostatsOffResponse['action_attempt']> {
-    const { data } = await this.client.request<ThermostatsOffResponse>({
-      url: '/thermostats/off',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ThermostatsOffBody,
+    ThermostatsOffResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/off',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async setFanMode(
+  setFanMode(
     body?: ThermostatsSetFanModeBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): Promise<ThermostatsSetFanModeResponse['action_attempt']> {
-    const { data } = await this.client.request<ThermostatsSetFanModeResponse>({
-      url: '/thermostats/set_fan_mode',
-      method: 'post',
-      data: body,
-    })
-    const waitForActionAttempt =
-      options.waitForActionAttempt ?? this.defaults.waitForActionAttempt
-    if (waitForActionAttempt !== false) {
-      return await resolveActionAttempt(
-        data.action_attempt,
-        SeamHttpActionAttempts.fromClient(this.client, {
-          ...this.defaults,
-          waitForActionAttempt: false,
-        }),
-        typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
-      )
-    }
-    return data.action_attempt
+  ): SeamApiRequest<
+    undefined | ThermostatsSetFanModeBody,
+    ThermostatsSetFanModeResponse,
+    'action_attempt'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/set_fan_mode',
+        method: 'post',
+        data: body,
+      },
+      'action_attempt',
+      options,
+    )
   }
 
-  async update(body?: ThermostatsUpdateBody): Promise<void> {
-    await this.client.request<ThermostatsUpdateResponse>({
-      url: '/thermostats/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: ThermostatsUpdateBody,
+  ): SeamApiRequest<undefined | ThermostatsUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/thermostats/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -165,11 +165,7 @@ export class SeamHttpThermostats {
   cool(
     body?: ThermostatsCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ThermostatsCoolBody,
-    ThermostatsCoolResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ThermostatsCoolResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/cool',
       method: 'post',
@@ -181,11 +177,7 @@ export class SeamHttpThermostats {
 
   get(
     body?: ThermostatsGetParams,
-  ): SeamHttpRequest<
-    undefined | ThermostatsGetParams,
-    ThermostatsGetResponse,
-    'thermostat'
-  > {
+  ): SeamHttpRequest<ThermostatsGetResponse, 'thermostat'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/get',
       method: 'post',
@@ -197,11 +189,7 @@ export class SeamHttpThermostats {
   heat(
     body?: ThermostatsHeatBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ThermostatsHeatBody,
-    ThermostatsHeatResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ThermostatsHeatResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/heat',
       method: 'post',
@@ -214,11 +202,7 @@ export class SeamHttpThermostats {
   heatCool(
     body?: ThermostatsHeatCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ThermostatsHeatCoolBody,
-    ThermostatsHeatCoolResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ThermostatsHeatCoolResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/heat_cool',
       method: 'post',
@@ -230,11 +214,7 @@ export class SeamHttpThermostats {
 
   list(
     body?: ThermostatsListParams,
-  ): SeamHttpRequest<
-    undefined | ThermostatsListParams,
-    ThermostatsListResponse,
-    'thermostats'
-  > {
+  ): SeamHttpRequest<ThermostatsListResponse, 'thermostats'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/list',
       method: 'post',
@@ -246,11 +226,7 @@ export class SeamHttpThermostats {
   off(
     body?: ThermostatsOffBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ThermostatsOffBody,
-    ThermostatsOffResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ThermostatsOffResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/off',
       method: 'post',
@@ -263,11 +239,7 @@ export class SeamHttpThermostats {
   setFanMode(
     body?: ThermostatsSetFanModeBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamHttpRequest<
-    undefined | ThermostatsSetFanModeBody,
-    ThermostatsSetFanModeResponse,
-    'action_attempt'
-  > {
+  ): SeamHttpRequest<ThermostatsSetFanModeResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/set_fan_mode',
       method: 'post',
@@ -277,9 +249,7 @@ export class SeamHttpThermostats {
     })
   }
 
-  update(
-    body?: ThermostatsUpdateBody,
-  ): SeamHttpRequest<undefined | ThermostatsUpdateBody, void, undefined> {
+  update(body?: ThermostatsUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/thermostats/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpThermostatsClimateSettingSchedules } from './thermostats-climate-setting-schedules.js'
@@ -165,12 +165,12 @@ export class SeamHttpThermostats {
   cool(
     body?: ThermostatsCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsCoolBody,
     ThermostatsCoolResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/cool',
@@ -184,12 +184,12 @@ export class SeamHttpThermostats {
 
   get(
     body?: ThermostatsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsGetParams,
     ThermostatsGetResponse,
     'thermostat'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/get',
@@ -203,12 +203,12 @@ export class SeamHttpThermostats {
   heat(
     body?: ThermostatsHeatBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsHeatBody,
     ThermostatsHeatResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/heat',
@@ -223,12 +223,12 @@ export class SeamHttpThermostats {
   heatCool(
     body?: ThermostatsHeatCoolBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsHeatCoolBody,
     ThermostatsHeatCoolResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/heat_cool',
@@ -242,12 +242,12 @@ export class SeamHttpThermostats {
 
   list(
     body?: ThermostatsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsListParams,
     ThermostatsListResponse,
     'thermostats'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/list',
@@ -261,12 +261,12 @@ export class SeamHttpThermostats {
   off(
     body?: ThermostatsOffBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsOffBody,
     ThermostatsOffResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/off',
@@ -281,12 +281,12 @@ export class SeamHttpThermostats {
   setFanMode(
     body?: ThermostatsSetFanModeBody,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | ThermostatsSetFanModeBody,
     ThermostatsSetFanModeResponse,
     'action_attempt'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/set_fan_mode',
@@ -300,8 +300,8 @@ export class SeamHttpThermostats {
 
   update(
     body?: ThermostatsUpdateBody,
-  ): SeamApiRequest<undefined | ThermostatsUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | ThermostatsUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/thermostats/update',

--- a/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
+++ b/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -159,12 +159,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
 
   delete(
     body?: UserIdentitiesEnrollmentAutomationsDeleteBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesEnrollmentAutomationsDeleteBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/enrollment_automations/delete',
@@ -177,12 +177,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
 
   get(
     body?: UserIdentitiesEnrollmentAutomationsGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesEnrollmentAutomationsGetParams,
     UserIdentitiesEnrollmentAutomationsGetResponse,
     'enrollment_automation'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/enrollment_automations/get',
@@ -195,12 +195,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
 
   launch(
     body?: UserIdentitiesEnrollmentAutomationsLaunchBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesEnrollmentAutomationsLaunchBody,
     UserIdentitiesEnrollmentAutomationsLaunchResponse,
     'enrollment_automation'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/enrollment_automations/launch',
@@ -213,12 +213,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
 
   list(
     body?: UserIdentitiesEnrollmentAutomationsListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesEnrollmentAutomationsListParams,
     UserIdentitiesEnrollmentAutomationsListResponse,
     'enrollment_automations'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/enrollment_automations/list',

--- a/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
+++ b/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
@@ -159,11 +159,7 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
 
   delete(
     body?: UserIdentitiesEnrollmentAutomationsDeleteBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesEnrollmentAutomationsDeleteBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/enrollment_automations/delete',
       method: 'post',
@@ -175,7 +171,6 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
   get(
     body?: UserIdentitiesEnrollmentAutomationsGetParams,
   ): SeamHttpRequest<
-    undefined | UserIdentitiesEnrollmentAutomationsGetParams,
     UserIdentitiesEnrollmentAutomationsGetResponse,
     'enrollment_automation'
   > {
@@ -190,7 +185,6 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
   launch(
     body?: UserIdentitiesEnrollmentAutomationsLaunchBody,
   ): SeamHttpRequest<
-    undefined | UserIdentitiesEnrollmentAutomationsLaunchBody,
     UserIdentitiesEnrollmentAutomationsLaunchResponse,
     'enrollment_automation'
   > {
@@ -205,7 +199,6 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
   list(
     body?: UserIdentitiesEnrollmentAutomationsListParams,
   ): SeamHttpRequest<
-    undefined | UserIdentitiesEnrollmentAutomationsListParams,
     UserIdentitiesEnrollmentAutomationsListResponse,
     'enrollment_automations'
   > {

--- a/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
+++ b/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
@@ -164,15 +164,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/enrollment_automations/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/enrollment_automations/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -182,15 +179,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     UserIdentitiesEnrollmentAutomationsGetResponse,
     'enrollment_automation'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/enrollment_automations/get',
-        method: 'post',
-        data: body,
-      },
-      'enrollment_automation',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/enrollment_automations/get',
+      method: 'post',
+      body,
+      responseKey: 'enrollment_automation',
+    })
   }
 
   launch(
@@ -200,15 +194,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     UserIdentitiesEnrollmentAutomationsLaunchResponse,
     'enrollment_automation'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/enrollment_automations/launch',
-        method: 'post',
-        data: body,
-      },
-      'enrollment_automation',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/enrollment_automations/launch',
+      method: 'post',
+      body,
+      responseKey: 'enrollment_automation',
+    })
   }
 
   list(
@@ -218,15 +209,12 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     UserIdentitiesEnrollmentAutomationsListResponse,
     'enrollment_automations'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/enrollment_automations/list',
-        method: 'post',
-        data: body,
-      },
-      'enrollment_automations',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/enrollment_automations/list',
+      method: 'post',
+      body,
+      responseKey: 'enrollment_automations',
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
+++ b/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,67 +157,76 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     await clientSessions.get()
   }
 
-  async delete(
+  delete(
     body?: UserIdentitiesEnrollmentAutomationsDeleteBody,
-  ): Promise<void> {
-    await this.client.request<UserIdentitiesEnrollmentAutomationsDeleteResponse>(
+  ): SeamApiRequest<
+    undefined | UserIdentitiesEnrollmentAutomationsDeleteBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
       {
         url: '/user_identities/enrollment_automations/delete',
         method: 'post',
         data: body,
       },
+      undefined,
     )
   }
 
-  async get(
+  get(
     body?: UserIdentitiesEnrollmentAutomationsGetParams,
-  ): Promise<
-    UserIdentitiesEnrollmentAutomationsGetResponse['enrollment_automation']
+  ): SeamApiRequest<
+    undefined | UserIdentitiesEnrollmentAutomationsGetParams,
+    UserIdentitiesEnrollmentAutomationsGetResponse,
+    'enrollment_automation'
   > {
-    const { data } =
-      await this.client.request<UserIdentitiesEnrollmentAutomationsGetResponse>(
-        {
-          url: '/user_identities/enrollment_automations/get',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.enrollment_automation
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/enrollment_automations/get',
+        method: 'post',
+        data: body,
+      },
+      'enrollment_automation',
+    )
   }
 
-  async launch(
+  launch(
     body?: UserIdentitiesEnrollmentAutomationsLaunchBody,
-  ): Promise<
-    UserIdentitiesEnrollmentAutomationsLaunchResponse['enrollment_automation']
+  ): SeamApiRequest<
+    undefined | UserIdentitiesEnrollmentAutomationsLaunchBody,
+    UserIdentitiesEnrollmentAutomationsLaunchResponse,
+    'enrollment_automation'
   > {
-    const { data } =
-      await this.client.request<UserIdentitiesEnrollmentAutomationsLaunchResponse>(
-        {
-          url: '/user_identities/enrollment_automations/launch',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.enrollment_automation
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/enrollment_automations/launch',
+        method: 'post',
+        data: body,
+      },
+      'enrollment_automation',
+    )
   }
 
-  async list(
+  list(
     body?: UserIdentitiesEnrollmentAutomationsListParams,
-  ): Promise<
-    UserIdentitiesEnrollmentAutomationsListResponse['enrollment_automations']
+  ): SeamApiRequest<
+    undefined | UserIdentitiesEnrollmentAutomationsListParams,
+    UserIdentitiesEnrollmentAutomationsListResponse,
+    'enrollment_automations'
   > {
-    const { data } =
-      await this.client.request<UserIdentitiesEnrollmentAutomationsListResponse>(
-        {
-          url: '/user_identities/enrollment_automations/list',
-          method: 'post',
-          data: body,
-        },
-      )
-
-    return data.enrollment_automations
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/enrollment_automations/list',
+        method: 'post',
+        data: body,
+      },
+      'enrollment_automations',
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpUserIdentitiesEnrollmentAutomations } from './user-identities-enrollment-automations.js'
@@ -161,133 +162,208 @@ export class SeamHttpUserIdentities {
     )
   }
 
-  async addAcsUser(body?: UserIdentitiesAddAcsUserBody): Promise<void> {
-    await this.client.request<UserIdentitiesAddAcsUserResponse>({
-      url: '/user_identities/add_acs_user',
-      method: 'post',
-      data: body,
-    })
+  addAcsUser(
+    body?: UserIdentitiesAddAcsUserBody,
+  ): SeamApiRequest<undefined | UserIdentitiesAddAcsUserBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/add_acs_user',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async create(
+  create(
     body?: UserIdentitiesCreateBody,
-  ): Promise<UserIdentitiesCreateResponse['user_identity']> {
-    const { data } = await this.client.request<UserIdentitiesCreateResponse>({
-      url: '/user_identities/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.user_identity
-  }
-
-  async delete(body?: UserIdentitiesDeleteBody): Promise<void> {
-    await this.client.request<UserIdentitiesDeleteResponse>({
-      url: '/user_identities/delete',
-      method: 'post',
-      data: body,
-    })
-  }
-
-  async get(
-    body?: UserIdentitiesGetParams,
-  ): Promise<UserIdentitiesGetResponse['user_identity']> {
-    const { data } = await this.client.request<UserIdentitiesGetResponse>({
-      url: '/user_identities/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.user_identity
-  }
-
-  async grantAccessToDevice(
-    body?: UserIdentitiesGrantAccessToDeviceBody,
-  ): Promise<void> {
-    await this.client.request<UserIdentitiesGrantAccessToDeviceResponse>({
-      url: '/user_identities/grant_access_to_device',
-      method: 'post',
-      data: body,
-    })
-  }
-
-  async list(
-    body?: UserIdentitiesListParams,
-  ): Promise<UserIdentitiesListResponse['user_identities']> {
-    const { data } = await this.client.request<UserIdentitiesListResponse>({
-      url: '/user_identities/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.user_identities
-  }
-
-  async listAccessibleDevices(
-    body?: UserIdentitiesListAccessibleDevicesParams,
-  ): Promise<
-    UserIdentitiesListAccessibleDevicesResponse['accessible_devices']
+  ): SeamApiRequest<
+    undefined | UserIdentitiesCreateBody,
+    UserIdentitiesCreateResponse,
+    'user_identity'
   > {
-    const { data } =
-      await this.client.request<UserIdentitiesListAccessibleDevicesResponse>({
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/create',
+        method: 'post',
+        data: body,
+      },
+      'user_identity',
+    )
+  }
+
+  delete(
+    body?: UserIdentitiesDeleteBody,
+  ): SeamApiRequest<undefined | UserIdentitiesDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
+  }
+
+  get(
+    body?: UserIdentitiesGetParams,
+  ): SeamApiRequest<
+    undefined | UserIdentitiesGetParams,
+    UserIdentitiesGetResponse,
+    'user_identity'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/get',
+        method: 'post',
+        data: body,
+      },
+      'user_identity',
+    )
+  }
+
+  grantAccessToDevice(
+    body?: UserIdentitiesGrantAccessToDeviceBody,
+  ): SeamApiRequest<
+    undefined | UserIdentitiesGrantAccessToDeviceBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/grant_access_to_device',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
+  }
+
+  list(
+    body?: UserIdentitiesListParams,
+  ): SeamApiRequest<
+    undefined | UserIdentitiesListParams,
+    UserIdentitiesListResponse,
+    'user_identities'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/list',
+        method: 'post',
+        data: body,
+      },
+      'user_identities',
+    )
+  }
+
+  listAccessibleDevices(
+    body?: UserIdentitiesListAccessibleDevicesParams,
+  ): SeamApiRequest<
+    undefined | UserIdentitiesListAccessibleDevicesParams,
+    UserIdentitiesListAccessibleDevicesResponse,
+    'accessible_devices'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/user_identities/list_accessible_devices',
         method: 'post',
         data: body,
-      })
-
-    return data.accessible_devices
+      },
+      'accessible_devices',
+    )
   }
 
-  async listAcsSystems(
+  listAcsSystems(
     body?: UserIdentitiesListAcsSystemsParams,
-  ): Promise<UserIdentitiesListAcsSystemsResponse['acs_systems']> {
-    const { data } =
-      await this.client.request<UserIdentitiesListAcsSystemsResponse>({
+  ): SeamApiRequest<
+    undefined | UserIdentitiesListAcsSystemsParams,
+    UserIdentitiesListAcsSystemsResponse,
+    'acs_systems'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/user_identities/list_acs_systems',
         method: 'post',
         data: body,
-      })
-
-    return data.acs_systems
+      },
+      'acs_systems',
+    )
   }
 
-  async listAcsUsers(
+  listAcsUsers(
     body?: UserIdentitiesListAcsUsersParams,
-  ): Promise<UserIdentitiesListAcsUsersResponse['acs_users']> {
-    const { data } =
-      await this.client.request<UserIdentitiesListAcsUsersResponse>({
+  ): SeamApiRequest<
+    undefined | UserIdentitiesListAcsUsersParams,
+    UserIdentitiesListAcsUsersResponse,
+    'acs_users'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
         url: '/user_identities/list_acs_users',
         method: 'post',
         data: body,
-      })
-
-    return data.acs_users
+      },
+      'acs_users',
+    )
   }
 
-  async removeAcsUser(body?: UserIdentitiesRemoveAcsUserBody): Promise<void> {
-    await this.client.request<UserIdentitiesRemoveAcsUserResponse>({
-      url: '/user_identities/remove_acs_user',
-      method: 'post',
-      data: body,
-    })
+  removeAcsUser(
+    body?: UserIdentitiesRemoveAcsUserBody,
+  ): SeamApiRequest<
+    undefined | UserIdentitiesRemoveAcsUserBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/remove_acs_user',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async revokeAccessToDevice(
+  revokeAccessToDevice(
     body?: UserIdentitiesRevokeAccessToDeviceBody,
-  ): Promise<void> {
-    await this.client.request<UserIdentitiesRevokeAccessToDeviceResponse>({
-      url: '/user_identities/revoke_access_to_device',
-      method: 'post',
-      data: body,
-    })
+  ): SeamApiRequest<
+    undefined | UserIdentitiesRevokeAccessToDeviceBody,
+    void,
+    undefined
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/revoke_access_to_device',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async update(body?: UserIdentitiesUpdateBody): Promise<void> {
-    await this.client.request<UserIdentitiesUpdateResponse>({
-      url: '/user_identities/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: UserIdentitiesUpdateBody,
+  ): SeamApiRequest<undefined | UserIdentitiesUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/user_identities/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 import { SeamHttpUserIdentitiesEnrollmentAutomations } from './user-identities-enrollment-automations.js'
@@ -164,8 +164,12 @@ export class SeamHttpUserIdentities {
 
   addAcsUser(
     body?: UserIdentitiesAddAcsUserBody,
-  ): SeamApiRequest<undefined | UserIdentitiesAddAcsUserBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<
+    undefined | UserIdentitiesAddAcsUserBody,
+    void,
+    undefined
+  > {
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/add_acs_user',
@@ -178,12 +182,12 @@ export class SeamHttpUserIdentities {
 
   create(
     body?: UserIdentitiesCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesCreateBody,
     UserIdentitiesCreateResponse,
     'user_identity'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/create',
@@ -196,8 +200,8 @@ export class SeamHttpUserIdentities {
 
   delete(
     body?: UserIdentitiesDeleteBody,
-  ): SeamApiRequest<undefined | UserIdentitiesDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | UserIdentitiesDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/delete',
@@ -210,12 +214,12 @@ export class SeamHttpUserIdentities {
 
   get(
     body?: UserIdentitiesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesGetParams,
     UserIdentitiesGetResponse,
     'user_identity'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/get',
@@ -228,12 +232,12 @@ export class SeamHttpUserIdentities {
 
   grantAccessToDevice(
     body?: UserIdentitiesGrantAccessToDeviceBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesGrantAccessToDeviceBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/grant_access_to_device',
@@ -246,12 +250,12 @@ export class SeamHttpUserIdentities {
 
   list(
     body?: UserIdentitiesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesListParams,
     UserIdentitiesListResponse,
     'user_identities'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/list',
@@ -264,12 +268,12 @@ export class SeamHttpUserIdentities {
 
   listAccessibleDevices(
     body?: UserIdentitiesListAccessibleDevicesParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesListAccessibleDevicesParams,
     UserIdentitiesListAccessibleDevicesResponse,
     'accessible_devices'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/list_accessible_devices',
@@ -282,12 +286,12 @@ export class SeamHttpUserIdentities {
 
   listAcsSystems(
     body?: UserIdentitiesListAcsSystemsParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesListAcsSystemsParams,
     UserIdentitiesListAcsSystemsResponse,
     'acs_systems'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/list_acs_systems',
@@ -300,12 +304,12 @@ export class SeamHttpUserIdentities {
 
   listAcsUsers(
     body?: UserIdentitiesListAcsUsersParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesListAcsUsersParams,
     UserIdentitiesListAcsUsersResponse,
     'acs_users'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/list_acs_users',
@@ -318,12 +322,12 @@ export class SeamHttpUserIdentities {
 
   removeAcsUser(
     body?: UserIdentitiesRemoveAcsUserBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesRemoveAcsUserBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/remove_acs_user',
@@ -336,12 +340,12 @@ export class SeamHttpUserIdentities {
 
   revokeAccessToDevice(
     body?: UserIdentitiesRevokeAccessToDeviceBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | UserIdentitiesRevokeAccessToDeviceBody,
     void,
     undefined
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/revoke_access_to_device',
@@ -354,8 +358,8 @@ export class SeamHttpUserIdentities {
 
   update(
     body?: UserIdentitiesUpdateBody,
-  ): SeamApiRequest<undefined | UserIdentitiesUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | UserIdentitiesUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/user_identities/update',

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -169,15 +169,12 @@ export class SeamHttpUserIdentities {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/add_acs_user',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/add_acs_user',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   create(
@@ -187,29 +184,23 @@ export class SeamHttpUserIdentities {
     UserIdentitiesCreateResponse,
     'user_identity'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/create',
-        method: 'post',
-        data: body,
-      },
-      'user_identity',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/create',
+      method: 'post',
+      body,
+      responseKey: 'user_identity',
+    })
   }
 
   delete(
     body?: UserIdentitiesDeleteBody,
   ): SeamHttpRequest<undefined | UserIdentitiesDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -219,15 +210,12 @@ export class SeamHttpUserIdentities {
     UserIdentitiesGetResponse,
     'user_identity'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/get',
-        method: 'post',
-        data: body,
-      },
-      'user_identity',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/get',
+      method: 'post',
+      body,
+      responseKey: 'user_identity',
+    })
   }
 
   grantAccessToDevice(
@@ -237,15 +225,12 @@ export class SeamHttpUserIdentities {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/grant_access_to_device',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/grant_access_to_device',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   list(
@@ -255,15 +240,12 @@ export class SeamHttpUserIdentities {
     UserIdentitiesListResponse,
     'user_identities'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/list',
-        method: 'post',
-        data: body,
-      },
-      'user_identities',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/list',
+      method: 'post',
+      body,
+      responseKey: 'user_identities',
+    })
   }
 
   listAccessibleDevices(
@@ -273,15 +255,12 @@ export class SeamHttpUserIdentities {
     UserIdentitiesListAccessibleDevicesResponse,
     'accessible_devices'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/list_accessible_devices',
-        method: 'post',
-        data: body,
-      },
-      'accessible_devices',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/list_accessible_devices',
+      method: 'post',
+      body,
+      responseKey: 'accessible_devices',
+    })
   }
 
   listAcsSystems(
@@ -291,15 +270,12 @@ export class SeamHttpUserIdentities {
     UserIdentitiesListAcsSystemsResponse,
     'acs_systems'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/list_acs_systems',
-        method: 'post',
-        data: body,
-      },
-      'acs_systems',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/list_acs_systems',
+      method: 'post',
+      body,
+      responseKey: 'acs_systems',
+    })
   }
 
   listAcsUsers(
@@ -309,15 +285,12 @@ export class SeamHttpUserIdentities {
     UserIdentitiesListAcsUsersResponse,
     'acs_users'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/list_acs_users',
-        method: 'post',
-        data: body,
-      },
-      'acs_users',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/list_acs_users',
+      method: 'post',
+      body,
+      responseKey: 'acs_users',
+    })
   }
 
   removeAcsUser(
@@ -327,15 +300,12 @@ export class SeamHttpUserIdentities {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/remove_acs_user',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/remove_acs_user',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   revokeAccessToDevice(
@@ -345,29 +315,23 @@ export class SeamHttpUserIdentities {
     void,
     undefined
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/revoke_access_to_device',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/revoke_access_to_device',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   update(
     body?: UserIdentitiesUpdateBody,
   ): SeamHttpRequest<undefined | UserIdentitiesUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/user_identities/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/user_identities/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -164,11 +164,7 @@ export class SeamHttpUserIdentities {
 
   addAcsUser(
     body?: UserIdentitiesAddAcsUserBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesAddAcsUserBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/add_acs_user',
       method: 'post',
@@ -179,11 +175,7 @@ export class SeamHttpUserIdentities {
 
   create(
     body?: UserIdentitiesCreateBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesCreateBody,
-    UserIdentitiesCreateResponse,
-    'user_identity'
-  > {
+  ): SeamHttpRequest<UserIdentitiesCreateResponse, 'user_identity'> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/create',
       method: 'post',
@@ -192,9 +184,7 @@ export class SeamHttpUserIdentities {
     })
   }
 
-  delete(
-    body?: UserIdentitiesDeleteBody,
-  ): SeamHttpRequest<undefined | UserIdentitiesDeleteBody, void, undefined> {
+  delete(body?: UserIdentitiesDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/delete',
       method: 'post',
@@ -205,11 +195,7 @@ export class SeamHttpUserIdentities {
 
   get(
     body?: UserIdentitiesGetParams,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesGetParams,
-    UserIdentitiesGetResponse,
-    'user_identity'
-  > {
+  ): SeamHttpRequest<UserIdentitiesGetResponse, 'user_identity'> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/get',
       method: 'post',
@@ -220,11 +206,7 @@ export class SeamHttpUserIdentities {
 
   grantAccessToDevice(
     body?: UserIdentitiesGrantAccessToDeviceBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesGrantAccessToDeviceBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/grant_access_to_device',
       method: 'post',
@@ -235,11 +217,7 @@ export class SeamHttpUserIdentities {
 
   list(
     body?: UserIdentitiesListParams,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesListParams,
-    UserIdentitiesListResponse,
-    'user_identities'
-  > {
+  ): SeamHttpRequest<UserIdentitiesListResponse, 'user_identities'> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/list',
       method: 'post',
@@ -251,7 +229,6 @@ export class SeamHttpUserIdentities {
   listAccessibleDevices(
     body?: UserIdentitiesListAccessibleDevicesParams,
   ): SeamHttpRequest<
-    undefined | UserIdentitiesListAccessibleDevicesParams,
     UserIdentitiesListAccessibleDevicesResponse,
     'accessible_devices'
   > {
@@ -265,11 +242,7 @@ export class SeamHttpUserIdentities {
 
   listAcsSystems(
     body?: UserIdentitiesListAcsSystemsParams,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesListAcsSystemsParams,
-    UserIdentitiesListAcsSystemsResponse,
-    'acs_systems'
-  > {
+  ): SeamHttpRequest<UserIdentitiesListAcsSystemsResponse, 'acs_systems'> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/list_acs_systems',
       method: 'post',
@@ -280,11 +253,7 @@ export class SeamHttpUserIdentities {
 
   listAcsUsers(
     body?: UserIdentitiesListAcsUsersParams,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesListAcsUsersParams,
-    UserIdentitiesListAcsUsersResponse,
-    'acs_users'
-  > {
+  ): SeamHttpRequest<UserIdentitiesListAcsUsersResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/list_acs_users',
       method: 'post',
@@ -295,11 +264,7 @@ export class SeamHttpUserIdentities {
 
   removeAcsUser(
     body?: UserIdentitiesRemoveAcsUserBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesRemoveAcsUserBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/remove_acs_user',
       method: 'post',
@@ -310,11 +275,7 @@ export class SeamHttpUserIdentities {
 
   revokeAccessToDevice(
     body?: UserIdentitiesRevokeAccessToDeviceBody,
-  ): SeamHttpRequest<
-    undefined | UserIdentitiesRevokeAccessToDeviceBody,
-    void,
-    undefined
-  > {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/revoke_access_to_device',
       method: 'post',
@@ -323,9 +284,7 @@ export class SeamHttpUserIdentities {
     })
   }
 
-  update(
-    body?: UserIdentitiesUpdateBody,
-  ): SeamHttpRequest<undefined | UserIdentitiesUpdateBody, void, undefined> {
+  update(body?: UserIdentitiesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/user_identities/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -156,11 +156,7 @@ export class SeamHttpWebhooks {
 
   create(
     body?: WebhooksCreateBody,
-  ): SeamHttpRequest<
-    undefined | WebhooksCreateBody,
-    WebhooksCreateResponse,
-    'webhook'
-  > {
+  ): SeamHttpRequest<WebhooksCreateResponse, 'webhook'> {
     return new SeamHttpRequest(this, {
       path: '/webhooks/create',
       method: 'post',
@@ -169,9 +165,7 @@ export class SeamHttpWebhooks {
     })
   }
 
-  delete(
-    body?: WebhooksDeleteBody,
-  ): SeamHttpRequest<undefined | WebhooksDeleteBody, void, undefined> {
+  delete(body?: WebhooksDeleteBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/webhooks/delete',
       method: 'post',
@@ -182,11 +176,7 @@ export class SeamHttpWebhooks {
 
   get(
     body?: WebhooksGetParams,
-  ): SeamHttpRequest<
-    undefined | WebhooksGetParams,
-    WebhooksGetResponse,
-    'webhook'
-  > {
+  ): SeamHttpRequest<WebhooksGetResponse, 'webhook'> {
     return new SeamHttpRequest(this, {
       path: '/webhooks/get',
       method: 'post',
@@ -197,11 +187,7 @@ export class SeamHttpWebhooks {
 
   list(
     body?: WebhooksListParams,
-  ): SeamHttpRequest<
-    undefined | WebhooksListParams,
-    WebhooksListResponse,
-    'webhooks'
-  > {
+  ): SeamHttpRequest<WebhooksListResponse, 'webhooks'> {
     return new SeamHttpRequest(this, {
       path: '/webhooks/list',
       method: 'post',
@@ -210,9 +196,7 @@ export class SeamHttpWebhooks {
     })
   }
 
-  update(
-    body?: WebhooksUpdateBody,
-  ): SeamHttpRequest<undefined | WebhooksUpdateBody, void, undefined> {
+  update(body?: WebhooksUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/webhooks/update',
       method: 'post',

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -161,29 +161,23 @@ export class SeamHttpWebhooks {
     WebhooksCreateResponse,
     'webhook'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/webhooks/create',
-        method: 'post',
-        data: body,
-      },
-      'webhook',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/webhooks/create',
+      method: 'post',
+      body,
+      responseKey: 'webhook',
+    })
   }
 
   delete(
     body?: WebhooksDeleteBody,
   ): SeamHttpRequest<undefined | WebhooksDeleteBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/webhooks/delete',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/webhooks/delete',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 
   get(
@@ -193,15 +187,12 @@ export class SeamHttpWebhooks {
     WebhooksGetResponse,
     'webhook'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/webhooks/get',
-        method: 'post',
-        data: body,
-      },
-      'webhook',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/webhooks/get',
+      method: 'post',
+      body,
+      responseKey: 'webhook',
+    })
   }
 
   list(
@@ -211,29 +202,23 @@ export class SeamHttpWebhooks {
     WebhooksListResponse,
     'webhooks'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/webhooks/list',
-        method: 'post',
-        data: body,
-      },
-      'webhooks',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/webhooks/list',
+      method: 'post',
+      body,
+      responseKey: 'webhooks',
+    })
   }
 
   update(
     body?: WebhooksUpdateBody,
   ): SeamHttpRequest<undefined | WebhooksUpdateBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/webhooks/update',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/webhooks/update',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,54 +154,86 @@ export class SeamHttpWebhooks {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: WebhooksCreateBody,
-  ): Promise<WebhooksCreateResponse['webhook']> {
-    const { data } = await this.client.request<WebhooksCreateResponse>({
-      url: '/webhooks/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.webhook
+  ): SeamApiRequest<
+    undefined | WebhooksCreateBody,
+    WebhooksCreateResponse,
+    'webhook'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/webhooks/create',
+        method: 'post',
+        data: body,
+      },
+      'webhook',
+    )
   }
 
-  async delete(body?: WebhooksDeleteBody): Promise<void> {
-    await this.client.request<WebhooksDeleteResponse>({
-      url: '/webhooks/delete',
-      method: 'post',
-      data: body,
-    })
+  delete(
+    body?: WebhooksDeleteBody,
+  ): SeamApiRequest<undefined | WebhooksDeleteBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/webhooks/delete',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 
-  async get(body?: WebhooksGetParams): Promise<WebhooksGetResponse['webhook']> {
-    const { data } = await this.client.request<WebhooksGetResponse>({
-      url: '/webhooks/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.webhook
+  get(
+    body?: WebhooksGetParams,
+  ): SeamApiRequest<
+    undefined | WebhooksGetParams,
+    WebhooksGetResponse,
+    'webhook'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/webhooks/get',
+        method: 'post',
+        data: body,
+      },
+      'webhook',
+    )
   }
 
-  async list(
+  list(
     body?: WebhooksListParams,
-  ): Promise<WebhooksListResponse['webhooks']> {
-    const { data } = await this.client.request<WebhooksListResponse>({
-      url: '/webhooks/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.webhooks
+  ): SeamApiRequest<
+    undefined | WebhooksListParams,
+    WebhooksListResponse,
+    'webhooks'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/webhooks/list',
+        method: 'post',
+        data: body,
+      },
+      'webhooks',
+    )
   }
 
-  async update(body?: WebhooksUpdateBody): Promise<void> {
-    await this.client.request<WebhooksUpdateResponse>({
-      url: '/webhooks/update',
-      method: 'post',
-      data: body,
-    })
+  update(
+    body?: WebhooksUpdateBody,
+  ): SeamApiRequest<undefined | WebhooksUpdateBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/webhooks/update',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpWebhooks {
 
   create(
     body?: WebhooksCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WebhooksCreateBody,
     WebhooksCreateResponse,
     'webhook'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/webhooks/create',
@@ -174,8 +174,8 @@ export class SeamHttpWebhooks {
 
   delete(
     body?: WebhooksDeleteBody,
-  ): SeamApiRequest<undefined | WebhooksDeleteBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | WebhooksDeleteBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/webhooks/delete',
@@ -188,12 +188,12 @@ export class SeamHttpWebhooks {
 
   get(
     body?: WebhooksGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WebhooksGetParams,
     WebhooksGetResponse,
     'webhook'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/webhooks/get',
@@ -206,12 +206,12 @@ export class SeamHttpWebhooks {
 
   list(
     body?: WebhooksListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WebhooksListParams,
     WebhooksListResponse,
     'webhooks'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/webhooks/list',
@@ -224,8 +224,8 @@ export class SeamHttpWebhooks {
 
   update(
     body?: WebhooksUpdateBody,
-  ): SeamApiRequest<undefined | WebhooksUpdateBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | WebhooksUpdateBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/webhooks/update',

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -156,11 +156,7 @@ export class SeamHttpWorkspaces {
 
   create(
     body?: WorkspacesCreateBody,
-  ): SeamHttpRequest<
-    undefined | WorkspacesCreateBody,
-    WorkspacesCreateResponse,
-    'workspace'
-  > {
+  ): SeamHttpRequest<WorkspacesCreateResponse, 'workspace'> {
     return new SeamHttpRequest(this, {
       path: '/workspaces/create',
       method: 'post',
@@ -171,11 +167,7 @@ export class SeamHttpWorkspaces {
 
   get(
     body?: WorkspacesGetParams,
-  ): SeamHttpRequest<
-    undefined | WorkspacesGetParams,
-    WorkspacesGetResponse,
-    'workspace'
-  > {
+  ): SeamHttpRequest<WorkspacesGetResponse, 'workspace'> {
     return new SeamHttpRequest(this, {
       path: '/workspaces/get',
       method: 'post',
@@ -186,11 +178,7 @@ export class SeamHttpWorkspaces {
 
   list(
     body?: WorkspacesListParams,
-  ): SeamHttpRequest<
-    undefined | WorkspacesListParams,
-    WorkspacesListResponse,
-    'workspaces'
-  > {
+  ): SeamHttpRequest<WorkspacesListResponse, 'workspaces'> {
     return new SeamHttpRequest(this, {
       path: '/workspaces/list',
       method: 'post',
@@ -201,7 +189,7 @@ export class SeamHttpWorkspaces {
 
   resetSandbox(
     body?: WorkspacesResetSandboxBody,
-  ): SeamHttpRequest<undefined | WorkspacesResetSandboxBody, void, undefined> {
+  ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
       path: '/workspaces/reset_sandbox',
       method: 'post',

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -161,15 +161,12 @@ export class SeamHttpWorkspaces {
     WorkspacesCreateResponse,
     'workspace'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/workspaces/create',
-        method: 'post',
-        data: body,
-      },
-      'workspace',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/workspaces/create',
+      method: 'post',
+      body,
+      responseKey: 'workspace',
+    })
   }
 
   get(
@@ -179,15 +176,12 @@ export class SeamHttpWorkspaces {
     WorkspacesGetResponse,
     'workspace'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/workspaces/get',
-        method: 'post',
-        data: body,
-      },
-      'workspace',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/workspaces/get',
+      method: 'post',
+      body,
+      responseKey: 'workspace',
+    })
   }
 
   list(
@@ -197,29 +191,23 @@ export class SeamHttpWorkspaces {
     WorkspacesListResponse,
     'workspaces'
   > {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/workspaces/list',
-        method: 'post',
-        data: body,
-      },
-      'workspaces',
-    )
+    return new SeamHttpRequest(this, {
+      path: '/workspaces/list',
+      method: 'post',
+      body,
+      responseKey: 'workspaces',
+    })
   }
 
   resetSandbox(
     body?: WorkspacesResetSandboxBody,
   ): SeamHttpRequest<undefined | WorkspacesResetSandboxBody, void, undefined> {
-    return new SeamHttpRequest(
-      this,
-      {
-        url: '/workspaces/reset_sandbox',
-        method: 'post',
-        data: body,
-      },
-      undefined,
-    )
+    return new SeamHttpRequest(this, {
+      path: '/workspaces/reset_sandbox',
+      method: 'post',
+      body,
+      responseKey: undefined,
+    })
   }
 }
 

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -31,7 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
-import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -156,12 +156,12 @@ export class SeamHttpWorkspaces {
 
   create(
     body?: WorkspacesCreateBody,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WorkspacesCreateBody,
     WorkspacesCreateResponse,
     'workspace'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/workspaces/create',
@@ -174,12 +174,12 @@ export class SeamHttpWorkspaces {
 
   get(
     body?: WorkspacesGetParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WorkspacesGetParams,
     WorkspacesGetResponse,
     'workspace'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/workspaces/get',
@@ -192,12 +192,12 @@ export class SeamHttpWorkspaces {
 
   list(
     body?: WorkspacesListParams,
-  ): SeamApiRequest<
+  ): SeamHttpRequest<
     undefined | WorkspacesListParams,
     WorkspacesListResponse,
     'workspaces'
   > {
-    return new SeamApiRequest(
+    return new SeamHttpRequest(
       this,
       {
         url: '/workspaces/list',
@@ -210,8 +210,8 @@ export class SeamHttpWorkspaces {
 
   resetSandbox(
     body?: WorkspacesResetSandboxBody,
-  ): SeamApiRequest<undefined | WorkspacesResetSandboxBody, void, undefined> {
-    return new SeamApiRequest(
+  ): SeamHttpRequest<undefined | WorkspacesResetSandboxBody, void, undefined> {
+    return new SeamHttpRequest(
       this,
       {
         url: '/workspaces/reset_sandbox',

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -31,6 +31,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/seam/connect/parse-options.js'
+import { SeamApiRequest } from 'lib/seam/connect/seam-api-request.js'
 
 import { SeamHttpClientSessions } from './client-sessions.js'
 
@@ -153,48 +154,72 @@ export class SeamHttpWorkspaces {
     await clientSessions.get()
   }
 
-  async create(
+  create(
     body?: WorkspacesCreateBody,
-  ): Promise<WorkspacesCreateResponse['workspace']> {
-    const { data } = await this.client.request<WorkspacesCreateResponse>({
-      url: '/workspaces/create',
-      method: 'post',
-      data: body,
-    })
-
-    return data.workspace
+  ): SeamApiRequest<
+    undefined | WorkspacesCreateBody,
+    WorkspacesCreateResponse,
+    'workspace'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/workspaces/create',
+        method: 'post',
+        data: body,
+      },
+      'workspace',
+    )
   }
 
-  async get(
+  get(
     body?: WorkspacesGetParams,
-  ): Promise<WorkspacesGetResponse['workspace']> {
-    const { data } = await this.client.request<WorkspacesGetResponse>({
-      url: '/workspaces/get',
-      method: 'post',
-      data: body,
-    })
-
-    return data.workspace
+  ): SeamApiRequest<
+    undefined | WorkspacesGetParams,
+    WorkspacesGetResponse,
+    'workspace'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/workspaces/get',
+        method: 'post',
+        data: body,
+      },
+      'workspace',
+    )
   }
 
-  async list(
+  list(
     body?: WorkspacesListParams,
-  ): Promise<WorkspacesListResponse['workspaces']> {
-    const { data } = await this.client.request<WorkspacesListResponse>({
-      url: '/workspaces/list',
-      method: 'post',
-      data: body,
-    })
-
-    return data.workspaces
+  ): SeamApiRequest<
+    undefined | WorkspacesListParams,
+    WorkspacesListResponse,
+    'workspaces'
+  > {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/workspaces/list',
+        method: 'post',
+        data: body,
+      },
+      'workspaces',
+    )
   }
 
-  async resetSandbox(body?: WorkspacesResetSandboxBody): Promise<void> {
-    await this.client.request<WorkspacesResetSandboxResponse>({
-      url: '/workspaces/reset_sandbox',
-      method: 'post',
-      data: body,
-    })
+  resetSandbox(
+    body?: WorkspacesResetSandboxBody,
+  ): SeamApiRequest<undefined | WorkspacesResetSandboxBody, void, undefined> {
+    return new SeamApiRequest(
+      this,
+      {
+        url: '/workspaces/reset_sandbox',
+        method: 'post',
+        data: body,
+      },
+      undefined,
+    )
   }
 }
 

--- a/src/lib/seam/connect/seam-api-request.ts
+++ b/src/lib/seam/connect/seam-api-request.ts
@@ -1,0 +1,95 @@
+import type { AxiosRequestConfig } from 'axios'
+import type { Client } from './client.js'
+import type { SeamHttpRequestOptions } from './options.js'
+import { resolveActionAttempt } from './resolve-action-attempt.js'
+import { SeamHttpActionAttempts } from './index.js'
+
+export interface SeamApiRequestParent {
+  readonly client: Client
+  readonly defaults: Required<SeamHttpRequestOptions>
+}
+
+export type ResponseFromSeamApiRequest<T> =
+  T extends SeamApiRequest<any, infer TResponse, infer TResourceKey>
+    ? TResourceKey extends keyof TResponse
+      ? TResponse[TResourceKey]
+      : void
+    : never
+
+export class SeamApiRequest<
+  const TBody,
+  const TResponse,
+  const TResourceKey extends keyof TResponse | undefined,
+> implements
+    PromiseLike<
+      TResourceKey extends keyof TResponse ? TResponse[TResourceKey] : undefined
+    >
+{
+  readonly parent: SeamApiRequestParent
+  readonly requestConfig: AxiosRequestConfig<TBody>
+  readonly resourceKey: TResourceKey
+  readonly options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
+
+  constructor(
+    parent: SeamApiRequestParent,
+    requestConfig: AxiosRequestConfig<TBody>,
+    resourceKey: TResourceKey,
+    options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
+  ) {
+    this.parent = parent
+    this.requestConfig = requestConfig
+    this.resourceKey = resourceKey
+    this.options = options
+  }
+
+  async execute(): Promise<
+    TResourceKey extends keyof TResponse ? TResponse[TResourceKey] : undefined
+  > {
+    const { client } = this.parent
+    const response = await client.request(this.requestConfig)
+    if (this.resourceKey === undefined) {
+      return undefined as TResourceKey extends keyof TResponse
+        ? TResponse[TResourceKey]
+        : undefined
+    }
+    const data = response.data[this.resourceKey]
+    if (this.resourceKey === 'action_attempt') {
+      const waitForActionAttempt =
+        this.options.waitForActionAttempt ??
+        this.parent.defaults.waitForActionAttempt
+      if (waitForActionAttempt !== false) {
+        return resolveActionAttempt(
+          data,
+          SeamHttpActionAttempts.fromClient(client, {
+            ...this.parent.defaults,
+            waitForActionAttempt: false,
+          }),
+          typeof waitForActionAttempt === 'boolean' ? {} : waitForActionAttempt,
+        )
+      }
+    }
+    return data
+  }
+
+  then<
+    TResult1 = TResourceKey extends keyof TResponse
+      ? TResponse[TResourceKey]
+      : undefined,
+    TResult2 = never,
+  >(
+    onfulfilled?:
+      | ((
+          value: TResourceKey extends keyof TResponse
+            ? TResponse[TResourceKey]
+            : undefined,
+        ) => TResult1 | PromiseLike<TResult1>)
+      | null
+      | undefined,
+    onrejected?:
+      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+      | null
+      | undefined,
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+}

--- a/src/lib/seam/connect/seam-api-request.ts
+++ b/src/lib/seam/connect/seam-api-request.ts
@@ -1,8 +1,9 @@
 import type { AxiosRequestConfig } from 'axios'
+
 import type { Client } from './client.js'
+import { SeamHttpActionAttempts } from './index.js'
 import type { SeamHttpRequestOptions } from './options.js'
 import { resolveActionAttempt } from './resolve-action-attempt.js'
-import { SeamHttpActionAttempts } from './index.js'
 
 export interface SeamApiRequestParent {
   readonly client: Client
@@ -13,7 +14,7 @@ export type ResponseFromSeamApiRequest<T> =
   T extends SeamApiRequest<any, infer TResponse, infer TResourceKey>
     ? TResourceKey extends keyof TResponse
       ? TResponse[TResourceKey]
-      : void
+      : undefined
     : never
 
 export class SeamApiRequest<
@@ -58,7 +59,7 @@ export class SeamApiRequest<
         this.options.waitForActionAttempt ??
         this.parent.defaults.waitForActionAttempt
       if (waitForActionAttempt !== false) {
-        return resolveActionAttempt(
+        return await resolveActionAttempt(
           data,
           SeamHttpActionAttempts.fromClient(client, {
             ...this.parent.defaults,

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -15,7 +15,7 @@ export interface SeamHttpRequestConfig<TBody, TResponseKey> {
   readonly path: string
   readonly method: Method
   readonly body?: TBody
-  readonly query?: undefined | Record<string, unknown>
+  readonly params?: undefined | Record<string, unknown>
   readonly responseKey: TResponseKey
   readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
 }
@@ -51,12 +51,12 @@ export class SeamHttpRequest<
       throw new Error('baseUrl is required')
     }
 
-    const query = this.#config.query
-    if (query === undefined) {
+    const params = this.#config.params
+    if (params === undefined) {
       return new URL(this.#config.path, baseUrl)
     }
     return new URL(
-      `${this.#config.path}?${serializeUrlSearchParams(query)}`,
+      `${this.#config.path}?${serializeUrlSearchParams(params)}`,
       baseUrl,
     )
   }
@@ -77,7 +77,7 @@ export class SeamHttpRequest<
       url: this.#config.path,
       method: this.#config.method,
       data: this.#config.body as TBody,
-      params: this.#config.query,
+      params: this.#config.params,
     })
     if (this.responseKey === undefined) {
       return undefined as TResponseKey extends keyof TResponse

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -11,9 +11,8 @@ interface SeamHttpRequestParent {
 }
 
 export interface SeamHttpRequestConfig<TBody, TResponseKey> {
-  readonly url?: string
+  readonly path?: string
   readonly method?: Method
-  readonly params?: any
   readonly data?: TBody
   readonly responseKey: TResponseKey
   readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
@@ -43,16 +42,12 @@ export class SeamHttpRequest<
     return this.#config.responseKey
   }
 
-  public get url(): string {
-    return this.#config.url ?? ''
+  public get path(): string {
+    return this.#config.path ?? ''
   }
 
   public get method(): Method {
     return this.#config.method ?? 'get'
-  }
-
-  public get params(): any {
-    return this.#config.params
   }
 
   public get data(): TBody {
@@ -64,9 +59,8 @@ export class SeamHttpRequest<
   > {
     const { client } = this.#parent
     const response = await client.request({
-      url: this.url,
+      url: this.path,
       method: this.method,
-      params: this.params,
       data: this.data,
     })
     if (this.responseKey === undefined) {

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -5,19 +5,19 @@ import { SeamHttpActionAttempts } from './index.js'
 import type { SeamHttpRequestOptions } from './options.js'
 import { resolveActionAttempt } from './resolve-action-attempt.js'
 
-export interface SeamApiRequestParent {
+export interface SeamHttpRequestParent {
   readonly client: Client
   readonly defaults: Required<SeamHttpRequestOptions>
 }
 
-export type ResponseFromSeamApiRequest<T> =
-  T extends SeamApiRequest<any, infer TResponse, infer TResourceKey>
+export type ResponseFromSeamHttpRequest<T> =
+  T extends SeamHttpRequest<any, infer TResponse, infer TResourceKey>
     ? TResourceKey extends keyof TResponse
       ? TResponse[TResourceKey]
       : undefined
     : never
 
-export class SeamApiRequest<
+export class SeamHttpRequest<
   const TBody,
   const TResponse,
   const TResourceKey extends keyof TResponse | undefined,
@@ -26,13 +26,13 @@ export class SeamApiRequest<
       TResourceKey extends keyof TResponse ? TResponse[TResourceKey] : undefined
     >
 {
-  readonly parent: SeamApiRequestParent
+  readonly parent: SeamHttpRequestParent
   readonly requestConfig: AxiosRequestConfig<TBody>
   readonly resourceKey: TResourceKey
   readonly options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
 
   constructor(
-    parent: SeamApiRequestParent,
+    parent: SeamHttpRequestParent,
     requestConfig: AxiosRequestConfig<TBody>,
     resourceKey: TResourceKey,
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -11,17 +11,16 @@ interface SeamHttpRequestParent {
   readonly defaults: Required<SeamHttpRequestOptions>
 }
 
-interface SeamHttpRequestConfig<TBody, TResponseKey> {
+interface SeamHttpRequestConfig<TResponseKey> {
   readonly path: string
   readonly method: Method
-  readonly body?: TBody
+  readonly body?: unknown
   readonly params?: undefined | Record<string, unknown>
   readonly responseKey: TResponseKey
   readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
 }
 
 export class SeamHttpRequest<
-  const TBody,
   const TResponse,
   const TResponseKey extends keyof TResponse | undefined,
 > implements
@@ -30,11 +29,11 @@ export class SeamHttpRequest<
     >
 {
   readonly #parent: SeamHttpRequestParent
-  readonly #config: SeamHttpRequestConfig<TBody, TResponseKey>
+  readonly #config: SeamHttpRequestConfig<TResponseKey>
 
   constructor(
     parent: SeamHttpRequestParent,
-    config: SeamHttpRequestConfig<TBody, TResponseKey>,
+    config: SeamHttpRequestConfig<TResponseKey>,
   ) {
     this.#parent = parent
     this.#config = config
@@ -68,8 +67,8 @@ export class SeamHttpRequest<
     return this.#config.method
   }
 
-  public get body(): TBody {
-    return this.#config.body as TBody
+  public get body(): unknown {
+    return this.#config.body
   }
 
   async execute(): Promise<
@@ -79,7 +78,7 @@ export class SeamHttpRequest<
     const response = await client.request({
       url: this.#config.path,
       method: this.#config.method,
-      data: this.#config.body as TBody,
+      data: this.#config.body,
       params: this.#config.params,
     })
     if (this.responseKey === undefined) {

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -55,10 +55,13 @@ export class SeamHttpRequest<
     if (params === undefined) {
       return new URL(this.#config.path, baseUrl)
     }
-    return new URL(
-      `${this.#config.path}?${serializeUrlSearchParams(params)}`,
-      baseUrl,
-    )
+
+    const serializer =
+      typeof client.defaults.paramsSerializer === 'function'
+        ? client.defaults.paramsSerializer
+        : serializeUrlSearchParams
+
+    return new URL(`${this.#config.path}?${serializer(params)}`, baseUrl)
   }
 
   public get method(): Method {

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -16,15 +16,8 @@ export interface SeamHttpRequestConfig<TBody, TResponseKey> {
   readonly params?: any
   readonly data?: TBody
   readonly responseKey: TResponseKey
-  readonly options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
+  readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
 }
-
-export type ResponseFromSeamHttpRequest<T> =
-  T extends SeamHttpRequest<any, infer TResponse, infer TResponseKey>
-    ? TResponseKey extends keyof TResponse
-      ? TResponse[TResponseKey]
-      : undefined
-    : never
 
 export class SeamHttpRequest<
   const TBody,
@@ -58,7 +51,7 @@ export class SeamHttpRequest<
     return this.#config.method ?? 'get'
   }
 
-  public get params() {
+  public get params(): any {
     return this.#config.params
   }
 
@@ -84,7 +77,7 @@ export class SeamHttpRequest<
     const data = response.data[this.responseKey]
     if (this.responseKey === 'action_attempt') {
       const waitForActionAttempt =
-        this.#config.options.waitForActionAttempt ??
+        this.#config.options?.waitForActionAttempt ??
         this.#parent.defaults.waitForActionAttempt
       if (waitForActionAttempt !== false) {
         return await resolveActionAttempt(

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -62,7 +62,7 @@ export class SeamHttpRequest<
   }
 
   public get method(): Method {
-    return this.#config.method ?? 'get'
+    return this.#config.method
   }
 
   public get body(): TBody {

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -10,10 +10,8 @@ import {
   type WorkspacesListResponse,
 } from '@seamapi/http/connect'
 
-import {
-  type ResponseFromSeamHttpRequest,
-  SeamHttpRequest,
-} from 'lib/seam/connect/seam-http-request.js'
+
+
 
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
   const { seed, endpoint } = await getTestServer(t)

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -164,32 +164,3 @@ test.failing(
     t.true(workspaces.length > 0)
   },
 )
-
-test('SeamHttp: request methods return a SeamHttpRequest object', async (t) => {
-  const { seed, endpoint } = await getTestServer(t)
-  const seam = new SeamHttp({
-    client: SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint }).client,
-  })
-
-  const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
-
-  t.true(deviceRequest instanceof SeamHttpRequest)
-  t.is(deviceRequest.url, '/devices/get')
-  t.deepEqual(deviceRequest.data, {
-    device_id: seed.august_device_1,
-  })
-  t.is(deviceRequest.resourceKey, 'device')
-  const device = await deviceRequest
-  t.is(device.workspace_id, seed.seed_workspace_1)
-  t.is(device.device_id, seed.august_device_1)
-
-  // Ensure that the type of the response is correct.
-  type Expected = ResponseFromSeamHttpRequest<typeof deviceRequest>
-
-  const validDeviceType: Expected['device_type'] = 'august_lock'
-  t.truthy(validDeviceType)
-
-  // @ts-expect-error because it's an invalid device type.
-  const invalidDeviceType: Expected['device_type'] = 'invalid_device_type'
-  t.truthy(invalidDeviceType)
-})

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   type ResponseFromSeamApiRequest,
   SeamApiRequest,
-} from 'lib/seam/connect/seam-api-request.js'
+} from 'lib/seam/connect/seam-http-request.js'
 
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
   const { seed, endpoint } = await getTestServer(t)

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -10,9 +10,6 @@ import {
   type WorkspacesListResponse,
 } from '@seamapi/http/connect'
 
-
-
-
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
   const { seed, endpoint } = await getTestServer(t)
   const seam = SeamHttp.fromClient(

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -9,9 +9,10 @@ import {
   SeamHttpMultiWorkspace,
   type WorkspacesListResponse,
 } from '@seamapi/http/connect'
+
 import {
-  SeamApiRequest,
   type ResponseFromSeamApiRequest,
+  SeamApiRequest,
 } from 'lib/seam/connect/seam-api-request.js'
 
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
@@ -185,10 +186,10 @@ test('SeamHttp: request methods return a SeamApiRequest object', async (t) => {
   // Ensure that the type of the response is correct.
   type Expected = ResponseFromSeamApiRequest<typeof deviceRequest>
 
-  const valid_device_type: Expected['device_type'] = 'august_lock'
-  t.truthy(valid_device_type)
+  const validDeviceType: Expected['device_type'] = 'august_lock'
+  t.truthy(validDeviceType)
 
   // @ts-expect-error because it's an invalid device type.
-  const invalid_device_type: Expected['device_type'] = 'invalid_device_type'
-  t.truthy(invalid_device_type)
+  const invalidDeviceType: Expected['device_type'] = 'invalid_device_type'
+  t.truthy(invalidDeviceType)
 })

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -9,6 +9,10 @@ import {
   SeamHttpMultiWorkspace,
   type WorkspacesListResponse,
 } from '@seamapi/http/connect'
+import {
+  SeamApiRequest,
+  type ResponseFromSeamApiRequest,
+} from 'lib/seam/connect/seam-api-request.js'
 
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
   const { seed, endpoint } = await getTestServer(t)
@@ -159,3 +163,32 @@ test.failing(
     t.true(workspaces.length > 0)
   },
 )
+
+test('SeamHttp: request methods return a SeamApiRequest object', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = new SeamHttp({
+    client: SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint }).client,
+  })
+
+  const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
+
+  t.true(deviceRequest instanceof SeamApiRequest)
+  t.is(deviceRequest.requestConfig.url, '/devices/get')
+  t.deepEqual(deviceRequest.requestConfig.data, {
+    device_id: seed.august_device_1,
+  })
+  t.is(deviceRequest.resourceKey, 'device')
+  const device = await deviceRequest
+  t.is(device.workspace_id, seed.seed_workspace_1)
+  t.is(device.device_id, seed.august_device_1)
+
+  // Ensure that the type of the response is correct.
+  type Expected = ResponseFromSeamApiRequest<typeof deviceRequest>
+
+  const valid_device_type: Expected['device_type'] = 'august_lock'
+  t.truthy(valid_device_type)
+
+  // @ts-expect-error because it's an invalid device type.
+  const invalid_device_type: Expected['device_type'] = 'invalid_device_type'
+  t.truthy(invalid_device_type)
+})

--- a/test/seam/connect/client.test.ts
+++ b/test/seam/connect/client.test.ts
@@ -11,8 +11,8 @@ import {
 } from '@seamapi/http/connect'
 
 import {
-  type ResponseFromSeamApiRequest,
-  SeamApiRequest,
+  type ResponseFromSeamHttpRequest,
+  SeamHttpRequest,
 } from 'lib/seam/connect/seam-http-request.js'
 
 test('SeamHttp: fromClient returns instance that uses client', async (t) => {
@@ -165,7 +165,7 @@ test.failing(
   },
 )
 
-test('SeamHttp: request methods return a SeamApiRequest object', async (t) => {
+test('SeamHttp: request methods return a SeamHttpRequest object', async (t) => {
   const { seed, endpoint } = await getTestServer(t)
   const seam = new SeamHttp({
     client: SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint }).client,
@@ -173,9 +173,9 @@ test('SeamHttp: request methods return a SeamApiRequest object', async (t) => {
 
   const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
 
-  t.true(deviceRequest instanceof SeamApiRequest)
-  t.is(deviceRequest.requestConfig.url, '/devices/get')
-  t.deepEqual(deviceRequest.requestConfig.data, {
+  t.true(deviceRequest instanceof SeamHttpRequest)
+  t.is(deviceRequest.url, '/devices/get')
+  t.deepEqual(deviceRequest.data, {
     device_id: seed.august_device_1,
   })
   t.is(deviceRequest.resourceKey, 'device')
@@ -184,7 +184,7 @@ test('SeamHttp: request methods return a SeamApiRequest object', async (t) => {
   t.is(device.device_id, seed.august_device_1)
 
   // Ensure that the type of the response is correct.
-  type Expected = ResponseFromSeamApiRequest<typeof deviceRequest>
+  type Expected = ResponseFromSeamHttpRequest<typeof deviceRequest>
 
   const validDeviceType: Expected['device_type'] = 'august_lock'
   t.truthy(validDeviceType)

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -2,9 +2,10 @@ import test from 'ava'
 import { getTestServer } from 'fixtures/seam/connect/api.js'
 
 import { SeamHttp } from '@seamapi/http/connect'
+
 import {
-  SeamHttpRequest,
   type ResponseFromSeamHttpRequest,
+  SeamHttpRequest,
 } from 'lib/seam/connect/seam-http-request.js'
 
 test('serializes array params when undefined', async (t) => {

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -3,12 +3,9 @@ import { getTestServer } from 'fixtures/seam/connect/api.js'
 
 import { SeamHttp } from '@seamapi/http/connect'
 
-import {
-  type ResponseFromSeamHttpRequest,
-  SeamHttpRequest,
-} from 'lib/seam/connect/seam-http-request.js'
+import { SeamHttpRequest } from 'lib/seam/connect/seam-http-request.js'
 
-test('serializes array params when undefined', async (t) => {
+test('returns a SeamHttpRequest', async (t) => {
   const { seed, endpoint } = await getTestServer(t)
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
 
@@ -34,3 +31,10 @@ test('serializes array params when undefined', async (t) => {
   const invalidDeviceType: Expected['device_type'] = 'invalid_device_type'
   t.truthy(invalidDeviceType)
 })
+
+type ResponseFromSeamHttpRequest<T> =
+  T extends SeamHttpRequest<any, infer TResponse, infer TResponseKey>
+    ? TResponseKey extends keyof TResponse
+      ? TResponse[TResponseKey]
+      : undefined
+    : never

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -12,7 +12,7 @@ test('returns a SeamHttpRequest', async (t) => {
   const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
 
   t.true(deviceRequest instanceof SeamHttpRequest)
-  t.is(deviceRequest.url, '/devices/get')
+  t.is(deviceRequest.path, '/devices/get')
   t.deepEqual(deviceRequest.data, {
     device_id: seed.august_device_1,
   })

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -163,7 +163,7 @@ const toPlainUrlObject = (url: URL): Omit<URL, 'searchParams' | 'toJSON'> => {
 }
 
 type ResponseFromSeamHttpRequest<T> =
-  T extends SeamHttpRequest<any, infer TResponse, infer TResponseKey>
+  T extends SeamHttpRequest<infer TResponse, infer TResponseKey>
     ? TResponseKey extends keyof TResponse
       ? TResponse[TResponseKey]
       : undefined

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava'
+import { getTestServer } from 'fixtures/seam/connect/api.js'
+
+import { SeamHttp } from '@seamapi/http/connect'
+import {
+  SeamHttpRequest,
+  type ResponseFromSeamHttpRequest,
+} from 'lib/seam/connect/seam-http-request.js'
+
+test('serializes array params when undefined', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
+
+  t.true(deviceRequest instanceof SeamHttpRequest)
+  t.is(deviceRequest.url, '/devices/get')
+  t.deepEqual(deviceRequest.data, {
+    device_id: seed.august_device_1,
+  })
+  t.is(deviceRequest.resourceKey, 'device')
+  const device = await deviceRequest
+  t.is(device.workspace_id, seed.seed_workspace_1)
+  t.is(device.device_id, seed.august_device_1)
+
+  // Ensure that the type of the response is correct.
+  type Expected = ResponseFromSeamHttpRequest<typeof deviceRequest>
+
+  const validDeviceType: Expected['device_type'] = 'august_lock'
+  t.truthy(validDeviceType)
+
+  // @ts-expect-error because it's an invalid device type.
+  const invalidDeviceType: Expected['device_type'] = 'invalid_device_type'
+  t.truthy(invalidDeviceType)
+})

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -12,8 +12,8 @@ test('returns a SeamHttpRequest', async (t) => {
   const deviceRequest = seam.devices.get({ device_id: seed.august_device_1 })
 
   t.true(deviceRequest instanceof SeamHttpRequest)
-  t.is(deviceRequest.path, '/devices/get')
-  t.deepEqual(deviceRequest.data, {
+  t.is(deviceRequest.url.pathname, '/devices/get')
+  t.deepEqual(deviceRequest.body, {
     device_id: seed.august_device_1,
   })
   t.is(deviceRequest.responseKey, 'device')
@@ -30,6 +30,28 @@ test('returns a SeamHttpRequest', async (t) => {
   // @ts-expect-error because it's an invalid device type.
   const invalidDeviceType: Expected['device_type'] = 'invalid_device_type'
   t.truthy(invalidDeviceType)
+})
+
+test("populates SeamHttpRequest's url property", async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  const deviceRequest = seam.devices.get({ device_id: 'abc123' })
+
+  t.is(deviceRequest.url.pathname, '/devices/get')
+  t.is(deviceRequest.url.search, '')
+
+  const connectWebviewsViewRequest = seam.connectWebviews.view({
+    connect_webview_id: 'abc123',
+    auth_token: 'invalid',
+  })
+
+  t.is(connectWebviewsViewRequest.url.pathname, '/connect_webviews/view')
+  t.is(connectWebviewsViewRequest.url.searchParams.get('auth_token'), 'invalid')
+  t.is(
+    connectWebviewsViewRequest.url.searchParams.get('connect_webview_id'),
+    'abc123',
+  )
 })
 
 type ResponseFromSeamHttpRequest<T> =

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -19,7 +19,7 @@ test('serializes array params when undefined', async (t) => {
   t.deepEqual(deviceRequest.data, {
     device_id: seed.august_device_1,
   })
-  t.is(deviceRequest.resourceKey, 'device')
+  t.is(deviceRequest.responseKey, 'device')
   const device = await deviceRequest
   t.is(device.workspace_id, seed.seed_workspace_1)
   t.is(device.device_id, seed.august_device_1)


### PR DESCRIPTION
It's often useful to be able to inspect an API Request before it is sent. This PR adds a new class, `SeamHttpRequest` which implements `PromiseLike<T>` which holds some information about the request before it is sent to the server. The actual request to the server is made when the `SeamHttpRequest` is `awaited`.

e.g.

```typescript
const request = client.devices.list();
console.log(request.url);
console.log(request.method);
console.log(request.body);
const devices = await request;
```

Of course the request can be awaited immediately, as normal:

```typescript
const devices = await client.devices.list();
```

I'm not married to the naming here so please feel free to bikeshed it 😄 