### PR TITLE
fix: SeamHttpRequest implements Promise<T> rather than PromiseLike<T>

### DIFF
--- a/src/lib/seam/connect/index.ts
+++ b/src/lib/seam/connect/index.ts
@@ -14,6 +14,7 @@ export * from './routes/index.js'
 export * from './seam-http.js'
 export * from './seam-http-error.js'
 export * from './seam-http-multi-workspace.js'
+export * from './seam-http-request.js'
 export {
   isApiKey,
   isClientSessionToken,

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -107,7 +107,7 @@ export class SeamHttpRequest<
     return data
   }
 
-  then<
+  async then<
     TResult1 = TResponseKey extends keyof TResponse
       ? TResponse[TResponseKey]
       : undefined,
@@ -126,10 +126,10 @@ export class SeamHttpRequest<
       | null
       | undefined,
   ): Promise<TResult1 | TResult2> {
-    return this.execute().then(onfulfilled, onrejected)
+    return await this.execute().then(onfulfilled, onrejected)
   }
 
-  catch<TResult = never>(
+  async catch<TResult = never>(
     onrejected?:
       | ((reason: any) => TResult | PromiseLike<TResult>)
       | null
@@ -140,15 +140,15 @@ export class SeamHttpRequest<
         : undefined)
     | TResult
   > {
-    return this.execute().catch(onrejected)
+    return await this.execute().catch(onrejected)
   }
 
-  finally(
+  async finally(
     onfinally?: (() => void) | null | undefined,
   ): Promise<
     TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
   > {
-    return this.execute().finally(onfinally)
+    return await this.execute().finally(onfinally)
   }
 }
 

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -107,7 +107,7 @@ export class SeamHttpRequest<
     return data
   }
 
-  async then<
+  then<
     TResult1 = TResponseKey extends keyof TResponse
       ? TResponse[TResponseKey]
       : undefined,
@@ -126,10 +126,10 @@ export class SeamHttpRequest<
       | null
       | undefined,
   ): Promise<TResult1 | TResult2> {
-    return await this.execute().then(onfulfilled, onrejected)
+    return this.execute().then(onfulfilled, onrejected)
   }
 
-  async catch<TResult = never>(
+  catch<TResult = never>(
     onrejected?:
       | ((reason: any) => TResult | PromiseLike<TResult>)
       | null
@@ -140,15 +140,15 @@ export class SeamHttpRequest<
         : undefined)
     | TResult
   > {
-    return await this.execute().catch(onrejected)
+    return this.execute().catch(onrejected)
   }
 
-  async finally(
+  finally(
     onfinally?: (() => void) | null | undefined,
   ): Promise<
     TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
   > {
-    return await this.execute().finally(onfinally)
+    return this.execute().finally(onfinally)
   }
 }
 

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -24,10 +24,12 @@ export class SeamHttpRequest<
   const TResponse,
   const TResponseKey extends keyof TResponse | undefined,
 > implements
-    PromiseLike<
+    Promise<
       TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
     >
 {
+  readonly [Symbol.toStringTag]: string = 'SeamHttpRequest'
+
   readonly #parent: SeamHttpRequestParent
   readonly #config: SeamHttpRequestConfig<TResponseKey>
 
@@ -105,7 +107,7 @@ export class SeamHttpRequest<
     return data
   }
 
-  then<
+  async then<
     TResult1 = TResponseKey extends keyof TResponse
       ? TResponse[TResponseKey]
       : undefined,
@@ -123,8 +125,30 @@ export class SeamHttpRequest<
       | ((reason: any) => TResult2 | PromiseLike<TResult2>)
       | null
       | undefined,
-  ): PromiseLike<TResult1 | TResult2> {
-    return this.execute().then(onfulfilled, onrejected)
+  ): Promise<TResult1 | TResult2> {
+    return await this.execute().then(onfulfilled, onrejected)
+  }
+
+  async catch<TResult = never>(
+    onrejected?:
+      | ((reason: any) => TResult | PromiseLike<TResult>)
+      | null
+      | undefined,
+  ): Promise<
+    | (TResponseKey extends keyof TResponse
+        ? TResponse[TResponseKey]
+        : undefined)
+    | TResult
+  > {
+    return await this.execute().catch(onrejected)
+  }
+
+  async finally(
+    onfinally?: (() => void) | null | undefined,
+  ): Promise<
+    TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
+  > {
+    return await this.execute().finally(onfinally)
   }
 }
 


### PR DESCRIPTION
It's not sufficient to implement `PromiseLike<T>` when libraries such as react query expect `T | Promise<T>`