### PR TITLE
Tests should use `/_fake` endpoints instead of fake db instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "axios-retry": "^4.0.0"
       },
       "devDependencies": {
-        "@seamapi/fake-seam-connect": "^1.44.2",
+        "@seamapi/fake-seam-connect": "^1.71.0",
         "@seamapi/types": "1.187.0",
         "@types/eslint": "^8.44.2",
         "@types/node": "^20.8.10",
@@ -1030,10 +1030,11 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-1.67.0.tgz",
-      "integrity": "sha512-oYUPfLWExI8WpVwj748ZjhJKMzYHhrFkwewhbeNmRb1oFfUChrsHRITtxeeL+7a7cc3p1n8DBYf3iW4g/++4ww==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-1.71.0.tgz",
+      "integrity": "sha512-yhGB/kgOEj/nQv8GMMS27JezVwuQgr7bH1bugKxVVcvrKJVnJpebDUZCT1TeBUoc6P4rtE/BcL6TJPxrQmfRNw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "fake-seam-connect": "dist/server.js"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "axios-retry": "^4.0.0"
   },
   "devDependencies": {
-    "@seamapi/fake-seam-connect": "^1.44.2",
+    "@seamapi/fake-seam-connect": "^1.71.0",
     "@seamapi/types": "1.187.0",
     "@types/eslint": "^8.44.2",
     "@types/node": "^20.8.10",

--- a/test/seam/connect/client-session-token.test.ts
+++ b/test/seam/connect/client-session-token.test.ts
@@ -56,10 +56,10 @@ test('SeamHttp: updateClientSessionToken returns instance authorized with a new 
   const seam = SeamHttp.fromClientSessionToken(seed.seam_cst1_token, {
     endpoint,
   })
-  const { token } = db.addClientSession({
-    workspace_id: seed.seed_workspace_1,
+  const { token } = await seam.clientSessions.create({
     user_identifier_key: 'some-new-user-identifier-key',
   })
+
   await seam.updateClientSessionToken(token)
   const devices = await seam.devices.list()
   t.is(devices.length, 0)

--- a/test/seam/connect/http-error.test.ts
+++ b/test/seam/connect/http-error.test.ts
@@ -10,17 +10,18 @@ import {
 } from '@seamapi/http/connect'
 
 test('SeamHttp: throws AxiosError on non-standard response', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
-
-  db.simulateWorkspaceOutage(seed.seed_workspace_1, {
-    routes: ['/devices/list'],
-  })
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
     axiosRetryOptions: {
       retries: 0,
     },
+  })
+
+  await seam.client.post('/_fake/simulate_workspace_outage', {
+    workspace_id: seed.seed_workspace_1,
+    routes: ['/devices/list'],
   })
 
   const err = await t.throwsAsync(async () => await seam.devices.list(), {

--- a/test/seam/connect/retry.test.ts
+++ b/test/seam/connect/retry.test.ts
@@ -5,12 +5,8 @@ import { getTestServer } from 'fixtures/seam/connect/api.js'
 import { SeamHttp } from '@seamapi/http/connect'
 
 test('SeamHttp: retries 503 status errors twice by default ', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
   const expectedRetryCount = 2
-
-  db.simulateWorkspaceOutage(seed.seed_workspace_1, {
-    routes: ['/devices/list'],
-  })
 
   t.plan(expectedRetryCount + 2)
 
@@ -21,6 +17,11 @@ test('SeamHttp: retries 503 status errors twice by default ', async (t) => {
         t.true(retryCount <= expectedRetryCount)
       },
     },
+  })
+
+  await seam.client.post('/_fake/simulate_workspace_outage', {
+    workspace_id: seed.seed_workspace_1,
+    routes: ['/devices/list'],
   })
 
   const err = await t.throwsAsync(

--- a/test/seam/connect/serialization.test.ts
+++ b/test/seam/connect/serialization.test.ts
@@ -9,7 +9,9 @@ test('serializes array params when undefined', async (t) => {
   const devices = await seam.devices.list({
     device_ids: undefined,
   })
-  t.is(devices.length, db.devices.length)
+  const { data: fakeDbDevices } = await seam.client.get('/_fake/database')
+
+  t.is(devices.length, fakeDbDevices.devices.length)
 })
 
 test('serializes array params when empty', async (t) => {
@@ -33,7 +35,7 @@ test('serializes array params when non-empty', async (t) => {
 })
 
 test('serializes array params when undefined and explicitly using get', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
   const { data } = await seam.client.get<DevicesListResponse>('/devices/list', {
     params: {
@@ -41,7 +43,9 @@ test('serializes array params when undefined and explicitly using get', async (t
     },
   })
   const devices = data?.devices
-  t.is(devices.length, db.devices.length)
+  const { data: fakeDbDevices } = await seam.client.get('/_fake/database')
+
+  t.is(devices.length, fakeDbDevices.devices.length)
 })
 
 test('serializes array params when empty and explicitly using get', async (t) => {

--- a/test/seam/connect/wait-for-action-attempt.test.ts
+++ b/test/seam/connect/wait-for-action-attempt.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@seamapi/http/connect'
 
 test('waitForActionAttempt: waits for pending action attempt', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
@@ -21,13 +21,13 @@ test('waitForActionAttempt: waits for pending action attempt', async (t) => {
 
   t.is(actionAttempt.status, 'pending')
 
-  db.updateActionAttempt({
+  await seam.client.post('/_fake/update_action_attempt', {
     action_attempt_id: actionAttempt.action_attempt_id,
     status: 'pending',
   })
 
-  setTimeout(() => {
-    db.updateActionAttempt({
+  setTimeout(async () => {
+    await seam.client.post('/_fake/update_action_attempt', {
       action_attempt_id: actionAttempt.action_attempt_id,
       status: 'success',
     })
@@ -45,7 +45,7 @@ test('waitForActionAttempt: waits for pending action attempt', async (t) => {
 })
 
 test('waitForActionAttempt: returns successful action attempt', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
@@ -58,7 +58,7 @@ test('waitForActionAttempt: returns successful action attempt', async (t) => {
 
   t.is(actionAttempt.status, 'pending')
 
-  db.updateActionAttempt({
+  await seam.client.post('/_fake/update_action_attempt', {
     action_attempt_id: actionAttempt.action_attempt_id,
     status: 'success',
   })
@@ -85,7 +85,7 @@ test('waitForActionAttempt: returns successful action attempt', async (t) => {
 })
 
 test('waitForActionAttempt: times out while waiting for action attempt', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
@@ -98,7 +98,7 @@ test('waitForActionAttempt: times out while waiting for action attempt', async (
 
   t.is(actionAttempt.status, 'pending')
 
-  db.updateActionAttempt({
+  await seam.client.post('/_fake/update_action_attempt', {
     action_attempt_id: actionAttempt.action_attempt_id,
     status: 'pending',
   })
@@ -122,7 +122,7 @@ test('waitForActionAttempt: times out while waiting for action attempt', async (
 })
 
 test('waitForActionAttempt: rejects when action attempt fails', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
@@ -135,7 +135,7 @@ test('waitForActionAttempt: rejects when action attempt fails', async (t) => {
 
   t.deepEqual(actionAttempt.status, 'pending')
 
-  db.updateActionAttempt({
+  await seam.client.post('/_fake/update_action_attempt', {
     action_attempt_id: actionAttempt.action_attempt_id,
     status: 'error',
     error: {
@@ -163,7 +163,7 @@ test('waitForActionAttempt: rejects when action attempt fails', async (t) => {
 })
 
 test('waitForActionAttempt: times out if waiting for polling interval', async (t) => {
-  const { seed, endpoint, db } = await getTestServer(t)
+  const { seed, endpoint } = await getTestServer(t)
 
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
     endpoint,
@@ -176,7 +176,7 @@ test('waitForActionAttempt: times out if waiting for polling interval', async (t
 
   t.is(actionAttempt.status, 'pending')
 
-  db.updateActionAttempt({
+  await seam.client.post('/_fake/update_action_attempt', {
     action_attempt_id: actionAttempt.action_attempt_id,
     status: 'pending',
   })


### PR DESCRIPTION
- **Convert test/seam/connect/client-session-token.test.ts**
- **Convert test/seam/connect/http-error.test.ts**
- **Convert test/seam/connect/retry.test.ts**
- **Convert test/seam/connect/serialization.test.ts**
- **Convert test/seam/connect/wait-for-action-attempt.test.ts**
