### PR TITLE
Rename path to pathname in SeamHttpRequestConfig

### DIFF
--- a/generate-routes.ts
+++ b/generate-routes.ts
@@ -370,7 +370,7 @@ const renderClassMethod = ({
       : `${renderResponseType({ name, namespace })}, '${resource}'`
   }> {
     return new SeamHttpRequest(this, {
-      path: '${path}',
+      pathname: '${path}',
       method: '${snakeCase(method)}', ${
         requestFormat === 'params' ? 'params,' : ''
       } ${requestFormat === 'body' ? 'body,' : ''}

--- a/src/lib/seam/connect/routes/access-codes-simulate.ts
+++ b/src/lib/seam/connect/routes/access-codes-simulate.ts
@@ -161,7 +161,7 @@ export class SeamHttpAccessCodesSimulate {
     'access_code'
   > {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/simulate/create_unmanaged_access_code',
+      pathname: '/access_codes/simulate/create_unmanaged_access_code',
       method: 'post',
       body,
       responseKey: 'access_code',

--- a/src/lib/seam/connect/routes/access-codes-unmanaged.ts
+++ b/src/lib/seam/connect/routes/access-codes-unmanaged.ts
@@ -158,7 +158,7 @@ export class SeamHttpAccessCodesUnmanaged {
     body?: AccessCodesUnmanagedConvertToManagedBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/unmanaged/convert_to_managed',
+      pathname: '/access_codes/unmanaged/convert_to_managed',
       method: 'post',
       body,
       responseKey: undefined,
@@ -169,7 +169,7 @@ export class SeamHttpAccessCodesUnmanaged {
     body?: AccessCodesUnmanagedDeleteParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/unmanaged/delete',
+      pathname: '/access_codes/unmanaged/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -180,7 +180,7 @@ export class SeamHttpAccessCodesUnmanaged {
     body?: AccessCodesUnmanagedGetParams,
   ): SeamHttpRequest<AccessCodesUnmanagedGetResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/unmanaged/get',
+      pathname: '/access_codes/unmanaged/get',
       method: 'post',
       body,
       responseKey: 'access_code',
@@ -191,7 +191,7 @@ export class SeamHttpAccessCodesUnmanaged {
     body?: AccessCodesUnmanagedListParams,
   ): SeamHttpRequest<AccessCodesUnmanagedListResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/unmanaged/list',
+      pathname: '/access_codes/unmanaged/list',
       method: 'post',
       body,
       responseKey: 'access_codes',
@@ -202,7 +202,7 @@ export class SeamHttpAccessCodesUnmanaged {
     body?: AccessCodesUnmanagedUpdateBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/unmanaged/update',
+      pathname: '/access_codes/unmanaged/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/access-codes.ts
+++ b/src/lib/seam/connect/routes/access-codes.ts
@@ -168,7 +168,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesCreateBody,
   ): SeamHttpRequest<AccessCodesCreateResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/create',
+      pathname: '/access_codes/create',
       method: 'post',
       body,
       responseKey: 'access_code',
@@ -179,7 +179,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesCreateMultipleBody,
   ): SeamHttpRequest<AccessCodesCreateMultipleResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/create_multiple',
+      pathname: '/access_codes/create_multiple',
       method: 'post',
       body,
       responseKey: 'access_codes',
@@ -188,7 +188,7 @@ export class SeamHttpAccessCodes {
 
   delete(body?: AccessCodesDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/delete',
+      pathname: '/access_codes/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -199,7 +199,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesGenerateCodeBody,
   ): SeamHttpRequest<AccessCodesGenerateCodeResponse, 'generated_code'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/generate_code',
+      pathname: '/access_codes/generate_code',
       method: 'post',
       body,
       responseKey: 'generated_code',
@@ -210,7 +210,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesGetParams,
   ): SeamHttpRequest<AccessCodesGetResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/get',
+      pathname: '/access_codes/get',
       method: 'post',
       body,
       responseKey: 'access_code',
@@ -221,7 +221,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesListParams,
   ): SeamHttpRequest<AccessCodesListResponse, 'access_codes'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/list',
+      pathname: '/access_codes/list',
       method: 'post',
       body,
       responseKey: 'access_codes',
@@ -232,7 +232,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesPullBackupAccessCodeBody,
   ): SeamHttpRequest<AccessCodesPullBackupAccessCodeResponse, 'access_code'> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/pull_backup_access_code',
+      pathname: '/access_codes/pull_backup_access_code',
       method: 'post',
       body,
       responseKey: 'access_code',
@@ -241,7 +241,7 @@ export class SeamHttpAccessCodes {
 
   update(body?: AccessCodesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/update',
+      pathname: '/access_codes/update',
       method: 'post',
       body,
       responseKey: undefined,
@@ -252,7 +252,7 @@ export class SeamHttpAccessCodes {
     body?: AccessCodesUpdateMultipleBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/access_codes/update_multiple',
+      pathname: '/access_codes/update_multiple',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/acs-access-groups-unmanaged.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups-unmanaged.ts
@@ -161,7 +161,7 @@ export class SeamHttpAcsAccessGroupsUnmanaged {
     body?: AcsAccessGroupsUnmanagedGetParams,
   ): SeamHttpRequest<AcsAccessGroupsUnmanagedGetResponse, 'acs_access_group'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/unmanaged/get',
+      pathname: '/acs/access_groups/unmanaged/get',
       method: 'post',
       body,
       responseKey: 'acs_access_group',
@@ -175,7 +175,7 @@ export class SeamHttpAcsAccessGroupsUnmanaged {
     'acs_access_groups'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/unmanaged/list',
+      pathname: '/acs/access_groups/unmanaged/list',
       method: 'post',
       body,
       responseKey: 'acs_access_groups',

--- a/src/lib/seam/connect/routes/acs-access-groups.ts
+++ b/src/lib/seam/connect/routes/acs-access-groups.ts
@@ -164,7 +164,7 @@ export class SeamHttpAcsAccessGroups {
 
   addUser(body?: AcsAccessGroupsAddUserBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/add_user',
+      pathname: '/acs/access_groups/add_user',
       method: 'post',
       body,
       responseKey: undefined,
@@ -175,7 +175,7 @@ export class SeamHttpAcsAccessGroups {
     body?: AcsAccessGroupsGetParams,
   ): SeamHttpRequest<AcsAccessGroupsGetResponse, 'acs_access_group'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/get',
+      pathname: '/acs/access_groups/get',
       method: 'post',
       body,
       responseKey: 'acs_access_group',
@@ -186,7 +186,7 @@ export class SeamHttpAcsAccessGroups {
     body?: AcsAccessGroupsListParams,
   ): SeamHttpRequest<AcsAccessGroupsListResponse, 'acs_access_groups'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/list',
+      pathname: '/acs/access_groups/list',
       method: 'post',
       body,
       responseKey: 'acs_access_groups',
@@ -200,7 +200,7 @@ export class SeamHttpAcsAccessGroups {
     'acs_entrances'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/list_accessible_entrances',
+      pathname: '/acs/access_groups/list_accessible_entrances',
       method: 'post',
       body,
       responseKey: 'acs_entrances',
@@ -211,7 +211,7 @@ export class SeamHttpAcsAccessGroups {
     body?: AcsAccessGroupsListUsersParams,
   ): SeamHttpRequest<AcsAccessGroupsListUsersResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/list_users',
+      pathname: '/acs/access_groups/list_users',
       method: 'post',
       body,
       responseKey: 'acs_users',
@@ -222,7 +222,7 @@ export class SeamHttpAcsAccessGroups {
     body?: AcsAccessGroupsRemoveUserParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/access_groups/remove_user',
+      pathname: '/acs/access_groups/remove_user',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/acs-credential-pools.ts
+++ b/src/lib/seam/connect/routes/acs-credential-pools.ts
@@ -158,7 +158,7 @@ export class SeamHttpAcsCredentialPools {
     body?: AcsCredentialPoolsListParams,
   ): SeamHttpRequest<AcsCredentialPoolsListResponse, 'acs_credential_pools'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credential_pools/list',
+      pathname: '/acs/credential_pools/list',
       method: 'post',
       body,
       responseKey: 'acs_credential_pools',

--- a/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
+++ b/src/lib/seam/connect/routes/acs-credential-provisioning-automations.ts
@@ -164,7 +164,7 @@ export class SeamHttpAcsCredentialProvisioningAutomations {
     'acs_credential_provisioning_automation'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/credential_provisioning_automations/launch',
+      pathname: '/acs/credential_provisioning_automations/launch',
       method: 'post',
       body,
       responseKey: 'acs_credential_provisioning_automation',

--- a/src/lib/seam/connect/routes/acs-credentials-unmanaged.ts
+++ b/src/lib/seam/connect/routes/acs-credentials-unmanaged.ts
@@ -161,7 +161,7 @@ export class SeamHttpAcsCredentialsUnmanaged {
     body?: AcsCredentialsUnmanagedGetParams,
   ): SeamHttpRequest<AcsCredentialsUnmanagedGetResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/unmanaged/get',
+      pathname: '/acs/credentials/unmanaged/get',
       method: 'post',
       body,
       responseKey: 'acs_credential',
@@ -172,7 +172,7 @@ export class SeamHttpAcsCredentialsUnmanaged {
     body?: AcsCredentialsUnmanagedListParams,
   ): SeamHttpRequest<AcsCredentialsUnmanagedListResponse, 'acs_credentials'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/unmanaged/list',
+      pathname: '/acs/credentials/unmanaged/list',
       method: 'post',
       body,
       responseKey: 'acs_credentials',

--- a/src/lib/seam/connect/routes/acs-credentials.ts
+++ b/src/lib/seam/connect/routes/acs-credentials.ts
@@ -164,7 +164,7 @@ export class SeamHttpAcsCredentials {
 
   assign(body?: AcsCredentialsAssignBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/assign',
+      pathname: '/acs/credentials/assign',
       method: 'post',
       body,
       responseKey: undefined,
@@ -175,7 +175,7 @@ export class SeamHttpAcsCredentials {
     body?: AcsCredentialsCreateBody,
   ): SeamHttpRequest<AcsCredentialsCreateResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/create',
+      pathname: '/acs/credentials/create',
       method: 'post',
       body,
       responseKey: 'acs_credential',
@@ -189,7 +189,7 @@ export class SeamHttpAcsCredentials {
     'acs_credential'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/create_offline_code',
+      pathname: '/acs/credentials/create_offline_code',
       method: 'post',
       body,
       responseKey: 'acs_credential',
@@ -198,7 +198,7 @@ export class SeamHttpAcsCredentials {
 
   delete(body?: AcsCredentialsDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/delete',
+      pathname: '/acs/credentials/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -209,7 +209,7 @@ export class SeamHttpAcsCredentials {
     body?: AcsCredentialsGetParams,
   ): SeamHttpRequest<AcsCredentialsGetResponse, 'acs_credential'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/get',
+      pathname: '/acs/credentials/get',
       method: 'post',
       body,
       responseKey: 'acs_credential',
@@ -220,7 +220,7 @@ export class SeamHttpAcsCredentials {
     body?: AcsCredentialsListParams,
   ): SeamHttpRequest<AcsCredentialsListResponse, 'acs_credentials'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/list',
+      pathname: '/acs/credentials/list',
       method: 'post',
       body,
       responseKey: 'acs_credentials',
@@ -234,7 +234,7 @@ export class SeamHttpAcsCredentials {
     'acs_entrances'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/list_accessible_entrances',
+      pathname: '/acs/credentials/list_accessible_entrances',
       method: 'post',
       body,
       responseKey: 'acs_entrances',
@@ -245,7 +245,7 @@ export class SeamHttpAcsCredentials {
     body?: AcsCredentialsUnassignBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/unassign',
+      pathname: '/acs/credentials/unassign',
       method: 'post',
       body,
       responseKey: undefined,
@@ -254,7 +254,7 @@ export class SeamHttpAcsCredentials {
 
   update(body?: AcsCredentialsUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/credentials/update',
+      pathname: '/acs/credentials/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/acs-encoders-simulate.ts
+++ b/src/lib/seam/connect/routes/acs-encoders-simulate.ts
@@ -158,7 +158,7 @@ export class SeamHttpAcsEncodersSimulate {
     body?: AcsEncodersSimulateNextCredentialEncodeWillFailBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/simulate/next_credential_encode_will_fail',
+      pathname: '/acs/encoders/simulate/next_credential_encode_will_fail',
       method: 'post',
       body,
       responseKey: undefined,
@@ -169,7 +169,7 @@ export class SeamHttpAcsEncodersSimulate {
     body?: AcsEncodersSimulateNextCredentialEncodeWillSucceedBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/simulate/next_credential_encode_will_succeed',
+      pathname: '/acs/encoders/simulate/next_credential_encode_will_succeed',
       method: 'post',
       body,
       responseKey: undefined,
@@ -180,7 +180,7 @@ export class SeamHttpAcsEncodersSimulate {
     body?: AcsEncodersSimulateNextCredentialScanWillFailBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/simulate/next_credential_scan_will_fail',
+      pathname: '/acs/encoders/simulate/next_credential_scan_will_fail',
       method: 'post',
       body,
       responseKey: undefined,
@@ -191,7 +191,7 @@ export class SeamHttpAcsEncodersSimulate {
     body?: AcsEncodersSimulateNextCredentialScanWillSucceedBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/simulate/next_credential_scan_will_succeed',
+      pathname: '/acs/encoders/simulate/next_credential_scan_will_succeed',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/acs-encoders.ts
+++ b/src/lib/seam/connect/routes/acs-encoders.ts
@@ -164,7 +164,7 @@ export class SeamHttpAcsEncoders {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<AcsEncodersEncodeCredentialResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/encode_credential',
+      pathname: '/acs/encoders/encode_credential',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -176,7 +176,7 @@ export class SeamHttpAcsEncoders {
     body?: AcsEncodersListParams,
   ): SeamHttpRequest<AcsEncodersListResponse, 'acs_encoders'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/list',
+      pathname: '/acs/encoders/list',
       method: 'post',
       body,
       responseKey: 'acs_encoders',
@@ -188,7 +188,7 @@ export class SeamHttpAcsEncoders {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<AcsEncodersScanCredentialResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/encoders/scan_credential',
+      pathname: '/acs/encoders/scan_credential',
       method: 'post',
       body,
       responseKey: 'action_attempt',

--- a/src/lib/seam/connect/routes/acs-entrances.ts
+++ b/src/lib/seam/connect/routes/acs-entrances.ts
@@ -158,7 +158,7 @@ export class SeamHttpAcsEntrances {
     body?: AcsEntrancesGetParams,
   ): SeamHttpRequest<AcsEntrancesGetResponse, 'acs_entrance'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/entrances/get',
+      pathname: '/acs/entrances/get',
       method: 'post',
       body,
       responseKey: 'acs_entrance',
@@ -169,7 +169,7 @@ export class SeamHttpAcsEntrances {
     body?: AcsEntrancesGrantAccessBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/entrances/grant_access',
+      pathname: '/acs/entrances/grant_access',
       method: 'post',
       body,
       responseKey: undefined,
@@ -180,7 +180,7 @@ export class SeamHttpAcsEntrances {
     body?: AcsEntrancesListParams,
   ): SeamHttpRequest<AcsEntrancesListResponse, 'acs_entrances'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/entrances/list',
+      pathname: '/acs/entrances/list',
       method: 'post',
       body,
       responseKey: 'acs_entrances',
@@ -194,7 +194,7 @@ export class SeamHttpAcsEntrances {
     'acs_credentials'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/entrances/list_credentials_with_access',
+      pathname: '/acs/entrances/list_credentials_with_access',
       method: 'post',
       body,
       responseKey: 'acs_credentials',

--- a/src/lib/seam/connect/routes/acs-systems.ts
+++ b/src/lib/seam/connect/routes/acs-systems.ts
@@ -158,7 +158,7 @@ export class SeamHttpAcsSystems {
     body?: AcsSystemsGetParams,
   ): SeamHttpRequest<AcsSystemsGetResponse, 'acs_system'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/systems/get',
+      pathname: '/acs/systems/get',
       method: 'post',
       body,
       responseKey: 'acs_system',
@@ -169,7 +169,7 @@ export class SeamHttpAcsSystems {
     body?: AcsSystemsListParams,
   ): SeamHttpRequest<AcsSystemsListResponse, 'acs_systems'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/systems/list',
+      pathname: '/acs/systems/list',
       method: 'post',
       body,
       responseKey: 'acs_systems',
@@ -183,7 +183,7 @@ export class SeamHttpAcsSystems {
     'acs_systems'
   > {
     return new SeamHttpRequest(this, {
-      path: '/acs/systems/list_compatible_credential_manager_acs_systems',
+      pathname: '/acs/systems/list_compatible_credential_manager_acs_systems',
       method: 'post',
       body,
       responseKey: 'acs_systems',

--- a/src/lib/seam/connect/routes/acs-users-unmanaged.ts
+++ b/src/lib/seam/connect/routes/acs-users-unmanaged.ts
@@ -158,7 +158,7 @@ export class SeamHttpAcsUsersUnmanaged {
     body?: AcsUsersUnmanagedGetParams,
   ): SeamHttpRequest<AcsUsersUnmanagedGetResponse, 'acs_user'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/unmanaged/get',
+      pathname: '/acs/users/unmanaged/get',
       method: 'post',
       body,
       responseKey: 'acs_user',
@@ -169,7 +169,7 @@ export class SeamHttpAcsUsersUnmanaged {
     body?: AcsUsersUnmanagedListParams,
   ): SeamHttpRequest<AcsUsersUnmanagedListResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/unmanaged/list',
+      pathname: '/acs/users/unmanaged/list',
       method: 'post',
       body,
       responseKey: 'acs_users',

--- a/src/lib/seam/connect/routes/acs-users.ts
+++ b/src/lib/seam/connect/routes/acs-users.ts
@@ -163,7 +163,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersAddToAccessGroupBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/add_to_access_group',
+      pathname: '/acs/users/add_to_access_group',
       method: 'post',
       body,
       responseKey: undefined,
@@ -174,7 +174,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersCreateBody,
   ): SeamHttpRequest<AcsUsersCreateResponse, 'acs_user'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/create',
+      pathname: '/acs/users/create',
       method: 'post',
       body,
       responseKey: 'acs_user',
@@ -183,7 +183,7 @@ export class SeamHttpAcsUsers {
 
   delete(body?: AcsUsersDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/delete',
+      pathname: '/acs/users/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -194,7 +194,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersGetParams,
   ): SeamHttpRequest<AcsUsersGetResponse, 'acs_user'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/get',
+      pathname: '/acs/users/get',
       method: 'post',
       body,
       responseKey: 'acs_user',
@@ -205,7 +205,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersListParams,
   ): SeamHttpRequest<AcsUsersListResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/list',
+      pathname: '/acs/users/list',
       method: 'post',
       body,
       responseKey: 'acs_users',
@@ -216,7 +216,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersListAccessibleEntrancesParams,
   ): SeamHttpRequest<AcsUsersListAccessibleEntrancesResponse, 'acs_entrances'> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/list_accessible_entrances',
+      pathname: '/acs/users/list_accessible_entrances',
       method: 'post',
       body,
       responseKey: 'acs_entrances',
@@ -227,7 +227,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersRemoveFromAccessGroupParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/remove_from_access_group',
+      pathname: '/acs/users/remove_from_access_group',
       method: 'post',
       body,
       responseKey: undefined,
@@ -238,7 +238,7 @@ export class SeamHttpAcsUsers {
     body?: AcsUsersRevokeAccessToAllEntrancesParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/revoke_access_to_all_entrances',
+      pathname: '/acs/users/revoke_access_to_all_entrances',
       method: 'post',
       body,
       responseKey: undefined,
@@ -247,7 +247,7 @@ export class SeamHttpAcsUsers {
 
   suspend(body?: AcsUsersSuspendBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/suspend',
+      pathname: '/acs/users/suspend',
       method: 'post',
       body,
       responseKey: undefined,
@@ -256,7 +256,7 @@ export class SeamHttpAcsUsers {
 
   unsuspend(body?: AcsUsersUnsuspendBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/unsuspend',
+      pathname: '/acs/users/unsuspend',
       method: 'post',
       body,
       responseKey: undefined,
@@ -265,7 +265,7 @@ export class SeamHttpAcsUsers {
 
   update(body?: AcsUsersUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/acs/users/update',
+      pathname: '/acs/users/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/action-attempts.ts
+++ b/src/lib/seam/connect/routes/action-attempts.ts
@@ -159,7 +159,7 @@ export class SeamHttpActionAttempts {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ActionAttemptsGetResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/action_attempts/get',
+      pathname: '/action_attempts/get',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -171,7 +171,7 @@ export class SeamHttpActionAttempts {
     body?: ActionAttemptsListParams,
   ): SeamHttpRequest<ActionAttemptsListResponse, 'action_attempts'> {
     return new SeamHttpRequest(this, {
-      path: '/action_attempts/list',
+      pathname: '/action_attempts/list',
       method: 'post',
       body,
       responseKey: 'action_attempts',

--- a/src/lib/seam/connect/routes/bridges.ts
+++ b/src/lib/seam/connect/routes/bridges.ts
@@ -156,7 +156,7 @@ export class SeamHttpBridges {
 
   get(body?: BridgesGetParams): SeamHttpRequest<BridgesGetResponse, 'bridge'> {
     return new SeamHttpRequest(this, {
-      path: '/bridges/get',
+      pathname: '/bridges/get',
       method: 'post',
       body,
       responseKey: 'bridge',
@@ -167,7 +167,7 @@ export class SeamHttpBridges {
     body?: BridgesListParams,
   ): SeamHttpRequest<BridgesListResponse, 'bridges'> {
     return new SeamHttpRequest(this, {
-      path: '/bridges/list',
+      pathname: '/bridges/list',
       method: 'post',
       body,
       responseKey: 'bridges',

--- a/src/lib/seam/connect/routes/client-sessions.ts
+++ b/src/lib/seam/connect/routes/client-sessions.ts
@@ -156,7 +156,7 @@ export class SeamHttpClientSessions {
     body?: ClientSessionsCreateBody,
   ): SeamHttpRequest<ClientSessionsCreateResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/create',
+      pathname: '/client_sessions/create',
       method: 'post',
       body,
       responseKey: 'client_session',
@@ -165,7 +165,7 @@ export class SeamHttpClientSessions {
 
   delete(body?: ClientSessionsDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/delete',
+      pathname: '/client_sessions/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -176,7 +176,7 @@ export class SeamHttpClientSessions {
     body?: ClientSessionsGetParams,
   ): SeamHttpRequest<ClientSessionsGetResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/get',
+      pathname: '/client_sessions/get',
       method: 'post',
       body,
       responseKey: 'client_session',
@@ -187,7 +187,7 @@ export class SeamHttpClientSessions {
     body?: ClientSessionsGetOrCreateBody,
   ): SeamHttpRequest<ClientSessionsGetOrCreateResponse, 'client_session'> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/get_or_create',
+      pathname: '/client_sessions/get_or_create',
       method: 'post',
       body,
       responseKey: 'client_session',
@@ -198,7 +198,7 @@ export class SeamHttpClientSessions {
     body?: ClientSessionsGrantAccessBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/grant_access',
+      pathname: '/client_sessions/grant_access',
       method: 'post',
       body,
       responseKey: undefined,
@@ -209,7 +209,7 @@ export class SeamHttpClientSessions {
     body?: ClientSessionsListParams,
   ): SeamHttpRequest<ClientSessionsListResponse, 'client_sessions'> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/list',
+      pathname: '/client_sessions/list',
       method: 'post',
       body,
       responseKey: 'client_sessions',
@@ -218,7 +218,7 @@ export class SeamHttpClientSessions {
 
   revoke(body?: ClientSessionsRevokeParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/client_sessions/revoke',
+      pathname: '/client_sessions/revoke',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/connect-webviews.ts
+++ b/src/lib/seam/connect/routes/connect-webviews.ts
@@ -158,7 +158,7 @@ export class SeamHttpConnectWebviews {
     body?: ConnectWebviewsCreateBody,
   ): SeamHttpRequest<ConnectWebviewsCreateResponse, 'connect_webview'> {
     return new SeamHttpRequest(this, {
-      path: '/connect_webviews/create',
+      pathname: '/connect_webviews/create',
       method: 'post',
       body,
       responseKey: 'connect_webview',
@@ -167,7 +167,7 @@ export class SeamHttpConnectWebviews {
 
   delete(body?: ConnectWebviewsDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/connect_webviews/delete',
+      pathname: '/connect_webviews/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -178,7 +178,7 @@ export class SeamHttpConnectWebviews {
     body?: ConnectWebviewsGetParams,
   ): SeamHttpRequest<ConnectWebviewsGetResponse, 'connect_webview'> {
     return new SeamHttpRequest(this, {
-      path: '/connect_webviews/get',
+      pathname: '/connect_webviews/get',
       method: 'post',
       body,
       responseKey: 'connect_webview',
@@ -189,7 +189,7 @@ export class SeamHttpConnectWebviews {
     body?: ConnectWebviewsListParams,
   ): SeamHttpRequest<ConnectWebviewsListResponse, 'connect_webviews'> {
     return new SeamHttpRequest(this, {
-      path: '/connect_webviews/list',
+      pathname: '/connect_webviews/list',
       method: 'post',
       body,
       responseKey: 'connect_webviews',

--- a/src/lib/seam/connect/routes/connected-accounts.ts
+++ b/src/lib/seam/connect/routes/connected-accounts.ts
@@ -158,7 +158,7 @@ export class SeamHttpConnectedAccounts {
     body?: ConnectedAccountsDeleteParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/connected_accounts/delete',
+      pathname: '/connected_accounts/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -169,7 +169,7 @@ export class SeamHttpConnectedAccounts {
     body?: ConnectedAccountsGetParams,
   ): SeamHttpRequest<ConnectedAccountsGetResponse, 'connected_account'> {
     return new SeamHttpRequest(this, {
-      path: '/connected_accounts/get',
+      pathname: '/connected_accounts/get',
       method: 'post',
       body,
       responseKey: 'connected_account',
@@ -180,7 +180,7 @@ export class SeamHttpConnectedAccounts {
     body?: ConnectedAccountsListParams,
   ): SeamHttpRequest<ConnectedAccountsListResponse, 'connected_accounts'> {
     return new SeamHttpRequest(this, {
-      path: '/connected_accounts/list',
+      pathname: '/connected_accounts/list',
       method: 'post',
       body,
       responseKey: 'connected_accounts',
@@ -189,7 +189,7 @@ export class SeamHttpConnectedAccounts {
 
   update(body?: ConnectedAccountsUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/connected_accounts/update',
+      pathname: '/connected_accounts/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/devices-simulate.ts
+++ b/src/lib/seam/connect/routes/devices-simulate.ts
@@ -156,7 +156,7 @@ export class SeamHttpDevicesSimulate {
 
   connect(body?: DevicesSimulateConnectBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/simulate/connect',
+      pathname: '/devices/simulate/connect',
       method: 'post',
       body,
       responseKey: undefined,
@@ -167,7 +167,7 @@ export class SeamHttpDevicesSimulate {
     body?: DevicesSimulateDisconnectBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/simulate/disconnect',
+      pathname: '/devices/simulate/disconnect',
       method: 'post',
       body,
       responseKey: undefined,
@@ -176,7 +176,7 @@ export class SeamHttpDevicesSimulate {
 
   remove(body?: DevicesSimulateRemoveBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/simulate/remove',
+      pathname: '/devices/simulate/remove',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/devices-unmanaged.ts
+++ b/src/lib/seam/connect/routes/devices-unmanaged.ts
@@ -158,7 +158,7 @@ export class SeamHttpDevicesUnmanaged {
     body?: DevicesUnmanagedGetParams,
   ): SeamHttpRequest<DevicesUnmanagedGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
-      path: '/devices/unmanaged/get',
+      pathname: '/devices/unmanaged/get',
       method: 'post',
       body,
       responseKey: 'device',
@@ -169,7 +169,7 @@ export class SeamHttpDevicesUnmanaged {
     body?: DevicesUnmanagedListParams,
   ): SeamHttpRequest<DevicesUnmanagedListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/devices/unmanaged/list',
+      pathname: '/devices/unmanaged/list',
       method: 'post',
       body,
       responseKey: 'devices',
@@ -178,7 +178,7 @@ export class SeamHttpDevicesUnmanaged {
 
   update(body?: DevicesUnmanagedUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/unmanaged/update',
+      pathname: '/devices/unmanaged/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/devices.ts
+++ b/src/lib/seam/connect/routes/devices.ts
@@ -166,7 +166,7 @@ export class SeamHttpDevices {
 
   delete(body?: DevicesDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/delete',
+      pathname: '/devices/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -175,7 +175,7 @@ export class SeamHttpDevices {
 
   get(body?: DevicesGetParams): SeamHttpRequest<DevicesGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
-      path: '/devices/get',
+      pathname: '/devices/get',
       method: 'post',
       body,
       responseKey: 'device',
@@ -186,7 +186,7 @@ export class SeamHttpDevices {
     body?: DevicesListParams,
   ): SeamHttpRequest<DevicesListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/devices/list',
+      pathname: '/devices/list',
       method: 'post',
       body,
       responseKey: 'devices',
@@ -197,7 +197,7 @@ export class SeamHttpDevices {
     body?: DevicesListDeviceProvidersParams,
   ): SeamHttpRequest<DevicesListDeviceProvidersResponse, 'device_providers'> {
     return new SeamHttpRequest(this, {
-      path: '/devices/list_device_providers',
+      pathname: '/devices/list_device_providers',
       method: 'post',
       body,
       responseKey: 'device_providers',
@@ -206,7 +206,7 @@ export class SeamHttpDevices {
 
   update(body?: DevicesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/devices/update',
+      pathname: '/devices/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/events.ts
+++ b/src/lib/seam/connect/routes/events.ts
@@ -156,7 +156,7 @@ export class SeamHttpEvents {
 
   get(body?: EventsGetParams): SeamHttpRequest<EventsGetResponse, 'event'> {
     return new SeamHttpRequest(this, {
-      path: '/events/get',
+      pathname: '/events/get',
       method: 'post',
       body,
       responseKey: 'event',
@@ -165,7 +165,7 @@ export class SeamHttpEvents {
 
   list(body?: EventsListParams): SeamHttpRequest<EventsListResponse, 'events'> {
     return new SeamHttpRequest(this, {
-      path: '/events/list',
+      pathname: '/events/list',
       method: 'post',
       body,
       responseKey: 'events',

--- a/src/lib/seam/connect/routes/locks.ts
+++ b/src/lib/seam/connect/routes/locks.ts
@@ -156,7 +156,7 @@ export class SeamHttpLocks {
 
   get(body?: LocksGetParams): SeamHttpRequest<LocksGetResponse, 'device'> {
     return new SeamHttpRequest(this, {
-      path: '/locks/get',
+      pathname: '/locks/get',
       method: 'post',
       body,
       responseKey: 'device',
@@ -165,7 +165,7 @@ export class SeamHttpLocks {
 
   list(body?: LocksListParams): SeamHttpRequest<LocksListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/locks/list',
+      pathname: '/locks/list',
       method: 'post',
       body,
       responseKey: 'devices',
@@ -177,7 +177,7 @@ export class SeamHttpLocks {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<LocksLockDoorResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/locks/lock_door',
+      pathname: '/locks/lock_door',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -190,7 +190,7 @@ export class SeamHttpLocks {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<LocksUnlockDoorResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/locks/unlock_door',
+      pathname: '/locks/unlock_door',
       method: 'post',
       body,
       responseKey: 'action_attempt',

--- a/src/lib/seam/connect/routes/networks.ts
+++ b/src/lib/seam/connect/routes/networks.ts
@@ -158,7 +158,7 @@ export class SeamHttpNetworks {
     body?: NetworksGetParams,
   ): SeamHttpRequest<NetworksGetResponse, 'network'> {
     return new SeamHttpRequest(this, {
-      path: '/networks/get',
+      pathname: '/networks/get',
       method: 'post',
       body,
       responseKey: 'network',
@@ -169,7 +169,7 @@ export class SeamHttpNetworks {
     body?: NetworksListParams,
   ): SeamHttpRequest<NetworksListResponse, 'networks'> {
     return new SeamHttpRequest(this, {
-      path: '/networks/list',
+      pathname: '/networks/list',
       method: 'post',
       body,
       responseKey: 'networks',

--- a/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-noise-thresholds.ts
@@ -164,7 +164,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     'noise_threshold'
   > {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/noise_thresholds/create',
+      pathname: '/noise_sensors/noise_thresholds/create',
       method: 'post',
       body,
       responseKey: 'noise_threshold',
@@ -175,7 +175,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     body?: NoiseSensorsNoiseThresholdsDeleteParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/noise_thresholds/delete',
+      pathname: '/noise_sensors/noise_thresholds/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -189,7 +189,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     'noise_threshold'
   > {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/noise_thresholds/get',
+      pathname: '/noise_sensors/noise_thresholds/get',
       method: 'post',
       body,
       responseKey: 'noise_threshold',
@@ -203,7 +203,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     'noise_thresholds'
   > {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/noise_thresholds/list',
+      pathname: '/noise_sensors/noise_thresholds/list',
       method: 'post',
       body,
       responseKey: 'noise_thresholds',
@@ -214,7 +214,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     body?: NoiseSensorsNoiseThresholdsUpdateBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/noise_thresholds/update',
+      pathname: '/noise_sensors/noise_thresholds/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/noise-sensors-simulate.ts
+++ b/src/lib/seam/connect/routes/noise-sensors-simulate.ts
@@ -158,7 +158,7 @@ export class SeamHttpNoiseSensorsSimulate {
     body?: NoiseSensorsSimulateTriggerNoiseThresholdBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/simulate/trigger_noise_threshold',
+      pathname: '/noise_sensors/simulate/trigger_noise_threshold',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/noise-sensors.ts
+++ b/src/lib/seam/connect/routes/noise-sensors.ts
@@ -171,7 +171,7 @@ export class SeamHttpNoiseSensors {
     body?: NoiseSensorsListParams,
   ): SeamHttpRequest<NoiseSensorsListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/noise_sensors/list',
+      pathname: '/noise_sensors/list',
       method: 'post',
       body,
       responseKey: 'devices',

--- a/src/lib/seam/connect/routes/phones-simulate.ts
+++ b/src/lib/seam/connect/routes/phones-simulate.ts
@@ -158,7 +158,7 @@ export class SeamHttpPhonesSimulate {
     body?: PhonesSimulateCreateSandboxPhoneBody,
   ): SeamHttpRequest<PhonesSimulateCreateSandboxPhoneResponse, 'phone'> {
     return new SeamHttpRequest(this, {
-      path: '/phones/simulate/create_sandbox_phone',
+      pathname: '/phones/simulate/create_sandbox_phone',
       method: 'post',
       body,
       responseKey: 'phone',

--- a/src/lib/seam/connect/routes/phones.ts
+++ b/src/lib/seam/connect/routes/phones.ts
@@ -161,7 +161,7 @@ export class SeamHttpPhones {
 
   deactivate(body?: PhonesDeactivateParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/phones/deactivate',
+      pathname: '/phones/deactivate',
       method: 'post',
       body,
       responseKey: undefined,
@@ -170,7 +170,7 @@ export class SeamHttpPhones {
 
   get(body?: PhonesGetParams): SeamHttpRequest<PhonesGetResponse, 'phone'> {
     return new SeamHttpRequest(this, {
-      path: '/phones/get',
+      pathname: '/phones/get',
       method: 'post',
       body,
       responseKey: 'phone',
@@ -179,7 +179,7 @@ export class SeamHttpPhones {
 
   list(body?: PhonesListParams): SeamHttpRequest<PhonesListResponse, 'phones'> {
     return new SeamHttpRequest(this, {
-      path: '/phones/list',
+      pathname: '/phones/list',
       method: 'post',
       body,
       responseKey: 'phones',

--- a/src/lib/seam/connect/routes/thermostats-schedules.ts
+++ b/src/lib/seam/connect/routes/thermostats-schedules.ts
@@ -161,7 +161,7 @@ export class SeamHttpThermostatsSchedules {
     'thermostat_schedule'
   > {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/schedules/create',
+      pathname: '/thermostats/schedules/create',
       method: 'post',
       body,
       responseKey: 'thermostat_schedule',
@@ -172,7 +172,7 @@ export class SeamHttpThermostatsSchedules {
     body?: ThermostatsSchedulesDeleteParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/schedules/delete',
+      pathname: '/thermostats/schedules/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -183,7 +183,7 @@ export class SeamHttpThermostatsSchedules {
     body?: ThermostatsSchedulesGetParams,
   ): SeamHttpRequest<ThermostatsSchedulesGetResponse, 'thermostat_schedule'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/schedules/get',
+      pathname: '/thermostats/schedules/get',
       method: 'post',
       body,
       responseKey: 'thermostat_schedule',
@@ -194,7 +194,7 @@ export class SeamHttpThermostatsSchedules {
     body?: ThermostatsSchedulesListParams,
   ): SeamHttpRequest<ThermostatsSchedulesListResponse, 'thermostat_schedules'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/schedules/list',
+      pathname: '/thermostats/schedules/list',
       method: 'post',
       body,
       responseKey: 'thermostat_schedules',
@@ -205,7 +205,7 @@ export class SeamHttpThermostatsSchedules {
     body?: ThermostatsSchedulesUpdateBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/schedules/update',
+      pathname: '/thermostats/schedules/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/thermostats-simulate.ts
+++ b/src/lib/seam/connect/routes/thermostats-simulate.ts
@@ -158,7 +158,7 @@ export class SeamHttpThermostatsSimulate {
     body?: ThermostatsSimulateHvacModeAdjustedBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/simulate/hvac_mode_adjusted',
+      pathname: '/thermostats/simulate/hvac_mode_adjusted',
       method: 'post',
       body,
       responseKey: undefined,
@@ -169,7 +169,7 @@ export class SeamHttpThermostatsSimulate {
     body?: ThermostatsSimulateTemperatureReachedBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/simulate/temperature_reached',
+      pathname: '/thermostats/simulate/temperature_reached',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/thermostats.ts
+++ b/src/lib/seam/connect/routes/thermostats.ts
@@ -172,7 +172,7 @@ export class SeamHttpThermostats {
     'action_attempt'
   > {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/activate_climate_preset',
+      pathname: '/thermostats/activate_climate_preset',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -185,7 +185,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsCoolResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/cool',
+      pathname: '/thermostats/cool',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -197,7 +197,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsCreateClimatePresetBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/create_climate_preset',
+      pathname: '/thermostats/create_climate_preset',
       method: 'post',
       body,
       responseKey: undefined,
@@ -208,7 +208,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsDeleteClimatePresetBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/delete_climate_preset',
+      pathname: '/thermostats/delete_climate_preset',
       method: 'post',
       body,
       responseKey: undefined,
@@ -219,7 +219,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsGetParams,
   ): SeamHttpRequest<ThermostatsGetResponse, 'thermostat'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/get',
+      pathname: '/thermostats/get',
       method: 'post',
       body,
       responseKey: 'thermostat',
@@ -231,7 +231,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsHeatResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/heat',
+      pathname: '/thermostats/heat',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -244,7 +244,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsHeatCoolResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/heat_cool',
+      pathname: '/thermostats/heat_cool',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -256,7 +256,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsListParams,
   ): SeamHttpRequest<ThermostatsListResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/list',
+      pathname: '/thermostats/list',
       method: 'post',
       body,
       responseKey: 'devices',
@@ -268,7 +268,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsOffResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/off',
+      pathname: '/thermostats/off',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -280,7 +280,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsSetFallbackClimatePresetBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/set_fallback_climate_preset',
+      pathname: '/thermostats/set_fallback_climate_preset',
       method: 'post',
       body,
       responseKey: undefined,
@@ -292,7 +292,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsSetFanModeResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/set_fan_mode',
+      pathname: '/thermostats/set_fan_mode',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -305,7 +305,7 @@ export class SeamHttpThermostats {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<ThermostatsSetHvacModeResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/set_hvac_mode',
+      pathname: '/thermostats/set_hvac_mode',
       method: 'post',
       body,
       responseKey: 'action_attempt',
@@ -317,7 +317,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsSetTemperatureThresholdBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/set_temperature_threshold',
+      pathname: '/thermostats/set_temperature_threshold',
       method: 'post',
       body,
       responseKey: undefined,
@@ -328,7 +328,7 @@ export class SeamHttpThermostats {
     body?: ThermostatsUpdateClimatePresetBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/thermostats/update_climate_preset',
+      pathname: '/thermostats/update_climate_preset',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
+++ b/src/lib/seam/connect/routes/user-identities-enrollment-automations.ts
@@ -161,7 +161,7 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     body?: UserIdentitiesEnrollmentAutomationsDeleteParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/enrollment_automations/delete',
+      pathname: '/user_identities/enrollment_automations/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -175,7 +175,7 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     'enrollment_automation'
   > {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/enrollment_automations/get',
+      pathname: '/user_identities/enrollment_automations/get',
       method: 'post',
       body,
       responseKey: 'enrollment_automation',
@@ -189,7 +189,7 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     'enrollment_automation'
   > {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/enrollment_automations/launch',
+      pathname: '/user_identities/enrollment_automations/launch',
       method: 'post',
       body,
       responseKey: 'enrollment_automation',
@@ -203,7 +203,7 @@ export class SeamHttpUserIdentitiesEnrollmentAutomations {
     'enrollment_automations'
   > {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/enrollment_automations/list',
+      pathname: '/user_identities/enrollment_automations/list',
       method: 'post',
       body,
       responseKey: 'enrollment_automations',

--- a/src/lib/seam/connect/routes/user-identities.ts
+++ b/src/lib/seam/connect/routes/user-identities.ts
@@ -166,7 +166,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesAddAcsUserBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/add_acs_user',
+      pathname: '/user_identities/add_acs_user',
       method: 'post',
       body,
       responseKey: undefined,
@@ -177,7 +177,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesCreateBody,
   ): SeamHttpRequest<UserIdentitiesCreateResponse, 'user_identity'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/create',
+      pathname: '/user_identities/create',
       method: 'post',
       body,
       responseKey: 'user_identity',
@@ -186,7 +186,7 @@ export class SeamHttpUserIdentities {
 
   delete(body?: UserIdentitiesDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/delete',
+      pathname: '/user_identities/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -197,7 +197,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesGetParams,
   ): SeamHttpRequest<UserIdentitiesGetResponse, 'user_identity'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/get',
+      pathname: '/user_identities/get',
       method: 'post',
       body,
       responseKey: 'user_identity',
@@ -208,7 +208,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesGrantAccessToDeviceBody,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/grant_access_to_device',
+      pathname: '/user_identities/grant_access_to_device',
       method: 'post',
       body,
       responseKey: undefined,
@@ -219,7 +219,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesListParams,
   ): SeamHttpRequest<UserIdentitiesListResponse, 'user_identities'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/list',
+      pathname: '/user_identities/list',
       method: 'post',
       body,
       responseKey: 'user_identities',
@@ -230,7 +230,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesListAccessibleDevicesParams,
   ): SeamHttpRequest<UserIdentitiesListAccessibleDevicesResponse, 'devices'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/list_accessible_devices',
+      pathname: '/user_identities/list_accessible_devices',
       method: 'post',
       body,
       responseKey: 'devices',
@@ -241,7 +241,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesListAcsSystemsParams,
   ): SeamHttpRequest<UserIdentitiesListAcsSystemsResponse, 'acs_systems'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/list_acs_systems',
+      pathname: '/user_identities/list_acs_systems',
       method: 'post',
       body,
       responseKey: 'acs_systems',
@@ -252,7 +252,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesListAcsUsersParams,
   ): SeamHttpRequest<UserIdentitiesListAcsUsersResponse, 'acs_users'> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/list_acs_users',
+      pathname: '/user_identities/list_acs_users',
       method: 'post',
       body,
       responseKey: 'acs_users',
@@ -263,7 +263,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesRemoveAcsUserParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/remove_acs_user',
+      pathname: '/user_identities/remove_acs_user',
       method: 'post',
       body,
       responseKey: undefined,
@@ -274,7 +274,7 @@ export class SeamHttpUserIdentities {
     body?: UserIdentitiesRevokeAccessToDeviceParams,
   ): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/revoke_access_to_device',
+      pathname: '/user_identities/revoke_access_to_device',
       method: 'post',
       body,
       responseKey: undefined,
@@ -283,7 +283,7 @@ export class SeamHttpUserIdentities {
 
   update(body?: UserIdentitiesUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/user_identities/update',
+      pathname: '/user_identities/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/webhooks.ts
+++ b/src/lib/seam/connect/routes/webhooks.ts
@@ -158,7 +158,7 @@ export class SeamHttpWebhooks {
     body?: WebhooksCreateBody,
   ): SeamHttpRequest<WebhooksCreateResponse, 'webhook'> {
     return new SeamHttpRequest(this, {
-      path: '/webhooks/create',
+      pathname: '/webhooks/create',
       method: 'post',
       body,
       responseKey: 'webhook',
@@ -167,7 +167,7 @@ export class SeamHttpWebhooks {
 
   delete(body?: WebhooksDeleteParams): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/webhooks/delete',
+      pathname: '/webhooks/delete',
       method: 'post',
       body,
       responseKey: undefined,
@@ -178,7 +178,7 @@ export class SeamHttpWebhooks {
     body?: WebhooksGetParams,
   ): SeamHttpRequest<WebhooksGetResponse, 'webhook'> {
     return new SeamHttpRequest(this, {
-      path: '/webhooks/get',
+      pathname: '/webhooks/get',
       method: 'post',
       body,
       responseKey: 'webhook',
@@ -189,7 +189,7 @@ export class SeamHttpWebhooks {
     body?: WebhooksListParams,
   ): SeamHttpRequest<WebhooksListResponse, 'webhooks'> {
     return new SeamHttpRequest(this, {
-      path: '/webhooks/list',
+      pathname: '/webhooks/list',
       method: 'post',
       body,
       responseKey: 'webhooks',
@@ -198,7 +198,7 @@ export class SeamHttpWebhooks {
 
   update(body?: WebhooksUpdateBody): SeamHttpRequest<void, undefined> {
     return new SeamHttpRequest(this, {
-      path: '/webhooks/update',
+      pathname: '/webhooks/update',
       method: 'post',
       body,
       responseKey: undefined,

--- a/src/lib/seam/connect/routes/workspaces.ts
+++ b/src/lib/seam/connect/routes/workspaces.ts
@@ -158,7 +158,7 @@ export class SeamHttpWorkspaces {
     body?: WorkspacesCreateBody,
   ): SeamHttpRequest<WorkspacesCreateResponse, 'workspace'> {
     return new SeamHttpRequest(this, {
-      path: '/workspaces/create',
+      pathname: '/workspaces/create',
       method: 'post',
       body,
       responseKey: 'workspace',
@@ -169,7 +169,7 @@ export class SeamHttpWorkspaces {
     body?: WorkspacesGetParams,
   ): SeamHttpRequest<WorkspacesGetResponse, 'workspace'> {
     return new SeamHttpRequest(this, {
-      path: '/workspaces/get',
+      pathname: '/workspaces/get',
       method: 'post',
       body,
       responseKey: 'workspace',
@@ -180,7 +180,7 @@ export class SeamHttpWorkspaces {
     body?: WorkspacesListParams,
   ): SeamHttpRequest<WorkspacesListResponse, 'workspaces'> {
     return new SeamHttpRequest(this, {
-      path: '/workspaces/list',
+      pathname: '/workspaces/list',
       method: 'post',
       body,
       responseKey: 'workspaces',
@@ -192,7 +192,7 @@ export class SeamHttpWorkspaces {
     options: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'> = {},
   ): SeamHttpRequest<WorkspacesResetSandboxResponse, 'action_attempt'> {
     return new SeamHttpRequest(this, {
-      path: '/workspaces/reset_sandbox',
+      pathname: '/workspaces/reset_sandbox',
       method: 'post',
       body,
       responseKey: 'action_attempt',

--- a/src/lib/seam/connect/seam-http-request.ts
+++ b/src/lib/seam/connect/seam-http-request.ts
@@ -12,7 +12,7 @@ interface SeamHttpRequestParent {
 }
 
 interface SeamHttpRequestConfig<TResponseKey> {
-  readonly path: string
+  readonly pathname: string
   readonly method: Method
   readonly body?: unknown
   readonly params?: undefined | Record<string, unknown>
@@ -56,9 +56,9 @@ export class SeamHttpRequest<
 
     const origin = getUrlPrefix(client.defaults.baseURL ?? '')
 
-    const pathname = this.#config.path.startsWith('/')
-      ? this.#config.path
-      : `/${this.#config.path}`
+    const pathname = this.#config.pathname.startsWith('/')
+      ? this.#config.pathname
+      : `/${this.#config.pathname}`
 
     const path = params == null ? pathname : `${pathname}?${serializer(params)}`
 
@@ -78,7 +78,7 @@ export class SeamHttpRequest<
   > {
     const { client } = this.#parent
     const response = await client.request({
-      url: this.#config.path,
+      url: this.#config.pathname,
       method: this.#config.method,
       data: this.#config.body,
       params: this.#config.params,


### PR DESCRIPTION
This is to match the spec: https://nodejs.org/api/url.html

This avoids ambiguity inside the module where path includes the query string and pathname does not.