### PR TITLE
feat: Default requests to a 30 second timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ the constructor takes some advanced options that affect behavior.
 const seam = new SeamHttp({
   apiKey: 'your-api-key',
   endpoint: 'https://example.com',
+  timeout: 30000,
   axiosOptions: {},
   axiosRetryOptions: {},
 })
@@ -438,6 +439,7 @@ these options may be passed in as the last argument.
 ```ts
 const seam = SeamHttp.fromApiKey('some-api-key', {
   endpoint: 'https://example.com',
+  timeout: 30000,
   axiosOptions: {},
   axiosRetryOptions: {},
 })
@@ -450,6 +452,22 @@ e.g., testing or proxy setups.
 This option corresponds to the Axios `baseURL` setting.
 
 Either pass the `endpoint` option, or set the `SEAM_ENDPOINT` environment variable.
+
+#### Setting the request timeout
+
+Requests time out after 30 seconds by default.
+Pass the `timeout` option, in milliseconds, to override this:
+
+```ts
+const seam = new SeamHttp({
+  apiKey: 'your-api-key',
+  timeout: 60000,
+})
+```
+
+Set `timeout` to `0` to disable the timeout entirely.
+A request that times out rejects with an Axios `ETIMEDOUT` error,
+and is retried according to the retry options.
 
 #### Configuring the Axios Client
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -6,7 +6,10 @@ import { errorInterceptor } from './error-interceptor.js'
 
 export type Client = AxiosInstance
 
+export const defaultTimeout = 30_000
+
 export interface ClientOptions {
+  timeout?: number
   axiosOptions?: AxiosRequestConfig
   axiosRetryOptions?: AxiosRetryConfig
 }
@@ -17,6 +20,7 @@ export const createClient = (options: ClientOptions): AxiosInstance => {
   const client = axios.create({
     paramsSerializer: serializeUrlSearchParams,
     adapter: 'fetch',
+    timeout: options.timeout ?? defaultTimeout,
     ...options.axiosOptions,
   })
 

--- a/src/lib/parse-options.ts
+++ b/src/lib/parse-options.ts
@@ -2,7 +2,7 @@ import { seamApiLtsVersion } from 'lib/lts-version.js'
 import version from 'lib/version.js'
 
 import { getAuthHeaders } from './auth.js'
-import type { Client, ClientOptions } from './client.js'
+import { type Client, type ClientOptions, defaultTimeout } from './client.js'
 import {
   isSeamHttpOptionsWithClient,
   isSeamHttpOptionsWithClientSessionToken,
@@ -40,6 +40,7 @@ export const parseOptions = (
 
   return {
     ...options,
+    timeout: options.timeout ?? defaultTimeout,
     axiosOptions: {
       baseURL: options.endpoint ?? getEndpointFromEnv() ?? defaultEndpoint,
       withCredentials: isSeamHttpOptionsWithClientSessionToken(options),

--- a/test/seam/connect/timeout.test.ts
+++ b/test/seam/connect/timeout.test.ts
@@ -1,0 +1,46 @@
+import test from 'ava'
+import { AxiosError } from 'axios'
+import { getTestServer } from 'fixtures/seam/connect/api.js'
+
+import { SeamHttp } from '@seamapi/http/connect'
+
+test('SeamHttp: times out requests after 30s by default', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+  t.is(seam.client.defaults.timeout, 30_000)
+})
+
+test('SeamHttp: timeout option overrides the default', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    timeout: 60_000,
+  })
+  t.is(seam.client.defaults.timeout, 60_000)
+})
+
+test('SeamHttp: axiosOptions timeout overrides the timeout option', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    timeout: 60_000,
+    axiosOptions: { timeout: 1_000 },
+  })
+  t.is(seam.client.defaults.timeout, 1_000)
+})
+
+test('SeamHttp: timeout option aborts slow requests', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    timeout: 1,
+    axiosRetryOptions: { retries: 0 },
+  })
+
+  const err = await t.throwsAsync(async () => await seam.devices.list(), {
+    instanceOf: AxiosError,
+  })
+
+  // The SDK uses the fetch adapter, which reports timeouts as ETIMEDOUT.
+  t.is(err?.code, AxiosError.ETIMEDOUT)
+})


### PR DESCRIPTION
Part of a four-SDK change adding a default HTTP timeout ([ruby](https://github.com/seamapi/ruby/pull/540), [python](https://github.com/seamapi/python/pull/601), [csharp](https://github.com/seamapi/csharp/pull/313)).

## Problem

Requests had no timeout, so a hung connection blocked the caller indefinitely. Axios defaults `timeout` to `0`, which means no timeout at all, and the SDK never set it.

## Changes

- Set the Axios `timeout` to 30 seconds by default, matching the API's own request timeout.
- Add a `timeout` option, in milliseconds, so callers can raise, lower, or disable it.
- Precedence keeps the low-level escape hatch authoritative: `axiosOptions.timeout` still wins over the `timeout` option.

```ts
const seam = new SeamHttp({ apiKey: 'your-api-key', timeout: 60000 })
```

Set `timeout` to `0` to disable it. A request that times out rejects with an Axios `ETIMEDOUT` error and is retried according to the retry options.

Note that the code is `ETIMEDOUT` rather than the more familiar `ECONNABORTED` because this SDK pins `adapter: 'fetch'`, and the fetch adapter raises timeouts through `composeSignals`. The XHR and http adapters would report `ECONNABORTED`.

## Behavior change

Requests that previously ran longer than 30 seconds will now fail with `ETIMEDOUT` instead of hanging. The `timeout` option is the opt-out.

## Testing

`test/seam/connect/timeout.test.ts` covers the default, the `timeout` option, `axiosOptions` precedence, and a request that actually aborts.

## Note for reviewers

Retries multiply the timeout. With the default of 2 retries, a fully hung endpoint is now bounded at roughly 90 seconds rather than forever. Retry behavior is otherwise untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1