### PR TITLE
refactor: drop the fetch adapter comment

### DIFF
--- a/test/seam/connect/timeout.test.ts
+++ b/test/seam/connect/timeout.test.ts
@@ -41,6 +41,5 @@ test('SeamHttp: timeout option aborts slow requests', async (t) => {
     instanceOf: AxiosError,
   })
 
-  // The SDK uses the fetch adapter, which reports timeouts as ETIMEDOUT.
   t.is(err?.code, AxiosError.ETIMEDOUT)
 })


### PR DESCRIPTION
Follow-up to #951, which is already merged and released in 2.3.0, so this is a new branch off `main` rather than more commits on the old one.

Removes the explanatory comment above the `ETIMEDOUT` assertion in `test/seam/connect/timeout.test.ts`. The assertion is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1)_