### PR TITLE
fix: validate request parameters when the request is made

### DIFF
--- a/codegen/layouts/partials/route-class-endpoint.hbs
+++ b/codegen/layouts/partials/route-class-endpoint.hbs
@@ -2,12 +2,13 @@
 {{methodName}}
 {{> endpont-method-signature }}
 {
-  assertValidRequestParameters(parameters, '{{path}}', {{hasRequiredParameters}}, [{{#each requiredParameterNames}}{{json .}}{{#unless @last}}, {{/unless}}{{/each}}])
-
   return new SeamHttpRequest(this, {
     pathname: '{{path}}',
     method: '{{method}}',
     {{requestFormat}}: parameters,
+    parameters,
+    hasRequiredParameters: {{hasRequiredParameters}},
+    requiredParameterNames: [{{#each requiredParameterNames}}{{json .}}{{#unless @last}}, {{/unless}}{{/each}}],
     responseKey: {{#if returnsVoid}}undefined{{else}}'{{responseKey}}'{{/if}},
     options,
     {{#if returnsActionAttempt}}

--- a/codegen/layouts/route.hbs
+++ b/codegen/layouts/route.hbs
@@ -5,9 +5,6 @@
 
 {{> route-imports }}
 
-{{#if endpoints}}
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
-{{/if}}
 {{#if needsRequireAtLeastOneImport}}
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 {{/if}}

--- a/src/lib/request-parameters.ts
+++ b/src/lib/request-parameters.ts
@@ -9,7 +9,7 @@ export const assertValidRequestParameters = (
   parameters: unknown,
   path: string,
   hasRequiredParameters: boolean,
-  requiredParameterNames: string[],
+  requiredParameterNames: readonly string[],
 ): void => {
   if (parameters === undefined) {
     if (hasRequiredParameters) {

--- a/src/lib/routes/access-codes/access-codes.ts
+++ b/src/lib/routes/access-codes/access-codes.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AccessCode } from 'lib/resources/access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -180,14 +177,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesCreateParameters,
     options: AccessCodesCreateOptions = {},
   ): AccessCodesCreateRequest {
-    assertValidRequestParameters(parameters, '/access_codes/create', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'access_code',
       options,
     })
@@ -210,17 +206,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesCreateMultipleParameters,
     options: AccessCodesCreateMultipleOptions = {},
   ): AccessCodesCreateMultipleRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/create_multiple',
-      true,
-      ['device_ids'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/create_multiple',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_ids'],
       responseKey: 'access_codes',
       options,
     })
@@ -233,14 +225,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesDeleteParameters,
     options: AccessCodesDeleteOptions = {},
   ): AccessCodesDeleteRequest {
-    assertValidRequestParameters(parameters, '/access_codes/delete', true, [
-      'access_code_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id'],
       responseKey: undefined,
       options,
     })
@@ -253,17 +244,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesGenerateCodeParameters,
     options: AccessCodesGenerateCodeOptions = {},
   ): AccessCodesGenerateCodeRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/generate_code',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/generate_code',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'generated_code',
       options,
     })
@@ -278,12 +265,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesGetParameters,
     options: AccessCodesGetOptions = {},
   ): AccessCodesGetRequest {
-    assertValidRequestParameters(parameters, '/access_codes/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'access_code',
       options,
     })
@@ -298,12 +286,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesListParameters,
     options: AccessCodesListOptions = {},
   ): AccessCodesListRequest {
-    assertValidRequestParameters(parameters, '/access_codes/list', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'access_codes',
       options,
     })
@@ -324,17 +313,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesPullBackupAccessCodeParameters,
     options: AccessCodesPullBackupAccessCodeOptions = {},
   ): AccessCodesPullBackupAccessCodeRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/pull_backup_access_code',
-      true,
-      ['access_code_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/pull_backup_access_code',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id'],
       responseKey: 'access_code',
       options,
     })
@@ -349,17 +334,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesReportDeviceConstraintsParameters,
     options: AccessCodesReportDeviceConstraintsOptions = {},
   ): AccessCodesReportDeviceConstraintsRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/report_device_constraints',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/report_device_constraints',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -374,14 +355,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesUpdateParameters,
     options: AccessCodesUpdateOptions = {},
   ): AccessCodesUpdateRequest {
-    assertValidRequestParameters(parameters, '/access_codes/update', true, [
-      'access_code_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/update',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id'],
       responseKey: undefined,
       options,
     })
@@ -398,17 +378,13 @@ export class SeamHttpAccessCodes {
     parameters: AccessCodesUpdateMultipleParameters,
     options: AccessCodesUpdateMultipleOptions = {},
   ): AccessCodesUpdateMultipleRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/update_multiple',
-      true,
-      ['common_code_key'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/update_multiple',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['common_code_key'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/access-codes/simulate/simulate.ts
+++ b/src/lib/routes/access-codes/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { UnmanagedAccessCode } from 'lib/resources/unmanaged-access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,13 @@ export class SeamHttpAccessCodesSimulate {
     parameters: AccessCodesSimulateCreateUnmanagedAccessCodeParameters,
     options: AccessCodesSimulateCreateUnmanagedAccessCodeOptions = {},
   ): AccessCodesSimulateCreateUnmanagedAccessCodeRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/simulate/create_unmanaged_access_code',
-      true,
-      ['code', 'device_id', 'name'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/simulate/create_unmanaged_access_code',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['code', 'device_id', 'name'],
       responseKey: 'access_code',
       options,
     })

--- a/src/lib/routes/access-codes/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-codes/unmanaged/unmanaged.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { UnmanagedAccessCode } from 'lib/resources/unmanaged-access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -173,17 +170,13 @@ export class SeamHttpAccessCodesUnmanaged {
     parameters: AccessCodesUnmanagedConvertToManagedParameters,
     options: AccessCodesUnmanagedConvertToManagedOptions = {},
   ): AccessCodesUnmanagedConvertToManagedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/unmanaged/convert_to_managed',
-      true,
-      ['access_code_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/unmanaged/convert_to_managed',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id'],
       responseKey: undefined,
       options,
     })
@@ -196,17 +189,13 @@ export class SeamHttpAccessCodesUnmanaged {
     parameters: AccessCodesUnmanagedDeleteParameters,
     options: AccessCodesUnmanagedDeleteOptions = {},
   ): AccessCodesUnmanagedDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/unmanaged/delete',
-      true,
-      ['access_code_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/unmanaged/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id'],
       responseKey: undefined,
       options,
     })
@@ -221,17 +210,13 @@ export class SeamHttpAccessCodesUnmanaged {
     parameters: AccessCodesUnmanagedGetParameters,
     options: AccessCodesUnmanagedGetOptions = {},
   ): AccessCodesUnmanagedGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/unmanaged/get',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/unmanaged/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'access_code',
       options,
     })
@@ -244,17 +229,13 @@ export class SeamHttpAccessCodesUnmanaged {
     parameters: AccessCodesUnmanagedListParameters,
     options: AccessCodesUnmanagedListOptions = {},
   ): AccessCodesUnmanagedListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/unmanaged/list',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/unmanaged/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'access_codes',
       options,
     })
@@ -267,17 +248,13 @@ export class SeamHttpAccessCodesUnmanaged {
     parameters: AccessCodesUnmanagedUpdateParameters,
     options: AccessCodesUnmanagedUpdateOptions = {},
   ): AccessCodesUnmanagedUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_codes/unmanaged/update',
-      true,
-      ['access_code_id', 'is_managed'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_codes/unmanaged/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_code_id', 'is_managed'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/access-grants/access-grants.ts
+++ b/src/lib/routes/access-grants/access-grants.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AccessGrant } from 'lib/resources/access-grant.js'
 import type { Batch } from 'lib/resources/batch.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -176,14 +173,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsCreateParameters,
     options: AccessGrantsCreateOptions = {},
   ): AccessGrantsCreateRequest {
-    assertValidRequestParameters(parameters, '/access_grants/create', true, [
-      'requested_access_methods',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['requested_access_methods'],
       responseKey: 'access_grant',
       options,
     })
@@ -196,14 +192,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsDeleteParameters,
     options: AccessGrantsDeleteOptions = {},
   ): AccessGrantsDeleteRequest {
-    assertValidRequestParameters(parameters, '/access_grants/delete', true, [
-      'access_grant_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_grant_id'],
       responseKey: undefined,
       options,
     })
@@ -216,12 +211,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsGetParameters,
     options: AccessGrantsGetOptions = {},
   ): AccessGrantsGetRequest {
-    assertValidRequestParameters(parameters, '/access_grants/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'access_grant',
       options,
     })
@@ -234,17 +230,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsGetRelatedParameters,
     options: AccessGrantsGetRelatedOptions = {},
   ): AccessGrantsGetRelatedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_grants/get_related',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/get_related',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'batch',
       options,
     })
@@ -257,12 +249,13 @@ export class SeamHttpAccessGrants {
     parameters?: AccessGrantsListParameters,
     options: AccessGrantsListOptions = {},
   ): AccessGrantsListRequest {
-    assertValidRequestParameters(parameters, '/access_grants/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'access_grants',
       options,
     })
@@ -275,17 +268,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsRequestAccessMethodsParameters,
     options: AccessGrantsRequestAccessMethodsOptions = {},
   ): AccessGrantsRequestAccessMethodsRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_grants/request_access_methods',
-      true,
-      ['access_grant_id', 'requested_access_methods'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/request_access_methods',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_grant_id', 'requested_access_methods'],
       responseKey: 'access_grant',
       options,
     })
@@ -298,12 +287,13 @@ export class SeamHttpAccessGrants {
     parameters: AccessGrantsUpdateParameters,
     options: AccessGrantsUpdateOptions = {},
   ): AccessGrantsUpdateRequest {
-    assertValidRequestParameters(parameters, '/access_grants/update', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/access-grants/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-grants/unmanaged/unmanaged.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { UnmanagedAccessGrant } from 'lib/resources/unmanaged-access-grant.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,13 @@ export class SeamHttpAccessGrantsUnmanaged {
     parameters: AccessGrantsUnmanagedGetParameters,
     options: AccessGrantsUnmanagedGetOptions = {},
   ): AccessGrantsUnmanagedGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_grants/unmanaged/get',
-      true,
-      ['access_grant_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/unmanaged/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_grant_id'],
       responseKey: 'access_grant',
       options,
     })
@@ -189,17 +184,13 @@ export class SeamHttpAccessGrantsUnmanaged {
     parameters?: AccessGrantsUnmanagedListParameters,
     options: AccessGrantsUnmanagedListOptions = {},
   ): AccessGrantsUnmanagedListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_grants/unmanaged/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/unmanaged/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'access_grants',
       options,
     })
@@ -216,17 +207,13 @@ export class SeamHttpAccessGrantsUnmanaged {
     parameters: AccessGrantsUnmanagedUpdateParameters,
     options: AccessGrantsUnmanagedUpdateOptions = {},
   ): AccessGrantsUnmanagedUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_grants/unmanaged/update',
-      true,
-      ['access_grant_id', 'is_managed'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_grants/unmanaged/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_grant_id', 'is_managed'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/access-methods/access-methods.ts
+++ b/src/lib/routes/access-methods/access-methods.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AccessMethod } from 'lib/resources/access-method.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Batch } from 'lib/resources/batch.js'
@@ -178,17 +175,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsAssignCardParameters,
     options: AccessMethodsAssignCardOptions = {},
   ): AccessMethodsAssignCardRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_methods/assign_card',
-      true,
-      ['access_method_id', 'card_number'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/assign_card',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_id', 'card_number'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -205,12 +198,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsDeleteParameters,
     options: AccessMethodsDeleteOptions = {},
   ): AccessMethodsDeleteRequest {
-    assertValidRequestParameters(parameters, '/access_methods/delete', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -223,15 +217,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsEncodeParameters,
     options: AccessMethodsEncodeOptions = {},
   ): AccessMethodsEncodeRequest {
-    assertValidRequestParameters(parameters, '/access_methods/encode', true, [
-      'access_method_id',
-      'acs_encoder_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/encode',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_id', 'acs_encoder_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -248,14 +240,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsGetParameters,
     options: AccessMethodsGetOptions = {},
   ): AccessMethodsGetRequest {
-    assertValidRequestParameters(parameters, '/access_methods/get', true, [
-      'access_method_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_id'],
       responseKey: 'access_method',
       options,
     })
@@ -268,17 +259,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsGetRelatedParameters,
     options: AccessMethodsGetRelatedOptions = {},
   ): AccessMethodsGetRelatedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_methods/get_related',
-      true,
-      ['access_method_ids'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/get_related',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_ids'],
       responseKey: 'batch',
       options,
     })
@@ -291,12 +278,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsListParameters,
     options: AccessMethodsListOptions = {},
   ): AccessMethodsListRequest {
-    assertValidRequestParameters(parameters, '/access_methods/list', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'access_methods',
       options,
     })
@@ -309,17 +297,13 @@ export class SeamHttpAccessMethods {
     parameters: AccessMethodsUnlockDoorParameters,
     options: AccessMethodsUnlockDoorOptions = {},
   ): AccessMethodsUnlockDoorRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_methods/unlock_door',
-      true,
-      ['access_method_id', 'acs_entrance_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/unlock_door',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_id', 'acs_entrance_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/access-methods/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-methods/unmanaged/unmanaged.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { UnmanagedAccessMethod } from 'lib/resources/unmanaged-access-method.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,13 @@ export class SeamHttpAccessMethodsUnmanaged {
     parameters: AccessMethodsUnmanagedGetParameters,
     options: AccessMethodsUnmanagedGetOptions = {},
   ): AccessMethodsUnmanagedGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_methods/unmanaged/get',
-      true,
-      ['access_method_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/unmanaged/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method_id'],
       responseKey: 'access_method',
       options,
     })
@@ -189,17 +184,13 @@ export class SeamHttpAccessMethodsUnmanaged {
     parameters: AccessMethodsUnmanagedListParameters,
     options: AccessMethodsUnmanagedListOptions = {},
   ): AccessMethodsUnmanagedListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/access_methods/unmanaged/list',
-      true,
-      ['access_grant_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/access_methods/unmanaged/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_grant_id'],
       responseKey: 'access_methods',
       options,
     })

--- a/src/lib/routes/acs/access-groups/access-groups.ts
+++ b/src/lib/routes/acs/access-groups/access-groups.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { AcsAccessGroup } from 'lib/resources/acs-access-group.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { AcsUser } from 'lib/resources/acs-user.js'
@@ -168,17 +167,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsAddUserParameters,
     options: AcsAccessGroupsAddUserOptions = {},
   ): AcsAccessGroupsAddUserRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/add_user',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/add_user',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: undefined,
       options,
     })
@@ -191,17 +186,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsDeleteParameters,
     options: AcsAccessGroupsDeleteOptions = {},
   ): AcsAccessGroupsDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/delete',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: undefined,
       options,
     })
@@ -214,14 +205,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsGetParameters,
     options: AcsAccessGroupsGetOptions = {},
   ): AcsAccessGroupsGetRequest {
-    assertValidRequestParameters(parameters, '/acs/access_groups/get', true, [
-      'acs_access_group_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: 'acs_access_group',
       options,
     })
@@ -234,17 +224,13 @@ export class SeamHttpAcsAccessGroups {
     parameters?: AcsAccessGroupsListParameters,
     options: AcsAccessGroupsListOptions = {},
   ): AcsAccessGroupsListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_access_groups',
       options,
     })
@@ -257,17 +243,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsListAccessibleEntrancesParameters,
     options: AcsAccessGroupsListAccessibleEntrancesOptions = {},
   ): AcsAccessGroupsListAccessibleEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/list_accessible_entrances',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/list_accessible_entrances',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: 'acs_entrances',
       options,
     })
@@ -280,17 +262,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsListUsersParameters,
     options: AcsAccessGroupsListUsersOptions = {},
   ): AcsAccessGroupsListUsersRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/list_users',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/list_users',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: 'acs_users',
       options,
     })
@@ -303,17 +281,13 @@ export class SeamHttpAcsAccessGroups {
     parameters: AcsAccessGroupsRemoveUserParameters,
     options: AcsAccessGroupsRemoveUserOptions = {},
   ): AcsAccessGroupsRemoveUserRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/access_groups/remove_user',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/access_groups/remove_user',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/credentials/credentials.ts
+++ b/src/lib/routes/acs/credentials/credentials.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { AcsCredential } from 'lib/resources/acs-credential.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -167,14 +166,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsAssignParameters,
     options: AcsCredentialsAssignOptions = {},
   ): AcsCredentialsAssignRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/assign', true, [
-      'acs_credential_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/assign',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: undefined,
       options,
     })
@@ -187,14 +185,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsCreateParameters,
     options: AcsCredentialsCreateOptions = {},
   ): AcsCredentialsCreateRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/create', true, [
-      'access_method',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['access_method'],
       responseKey: 'acs_credential',
       options,
     })
@@ -207,14 +204,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsDeleteParameters,
     options: AcsCredentialsDeleteOptions = {},
   ): AcsCredentialsDeleteRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/delete', true, [
-      'acs_credential_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: undefined,
       options,
     })
@@ -227,14 +223,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsGetParameters,
     options: AcsCredentialsGetOptions = {},
   ): AcsCredentialsGetRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/get', true, [
-      'acs_credential_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: 'acs_credential',
       options,
     })
@@ -247,12 +242,13 @@ export class SeamHttpAcsCredentials {
     parameters?: AcsCredentialsListParameters,
     options: AcsCredentialsListOptions = {},
   ): AcsCredentialsListRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_credentials',
       options,
     })
@@ -265,17 +261,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsListAccessibleEntrancesParameters,
     options: AcsCredentialsListAccessibleEntrancesOptions = {},
   ): AcsCredentialsListAccessibleEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/credentials/list_accessible_entrances',
-      true,
-      ['acs_credential_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/list_accessible_entrances',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: 'acs_entrances',
       options,
     })
@@ -288,17 +280,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsUnassignParameters,
     options: AcsCredentialsUnassignOptions = {},
   ): AcsCredentialsUnassignRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/credentials/unassign',
-      true,
-      ['acs_credential_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/unassign',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: undefined,
       options,
     })
@@ -311,14 +299,13 @@ export class SeamHttpAcsCredentials {
     parameters: AcsCredentialsUpdateParameters,
     options: AcsCredentialsUpdateOptions = {},
   ): AcsCredentialsUpdateRequest {
-    assertValidRequestParameters(parameters, '/acs/credentials/update', true, [
-      'acs_credential_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/credentials/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/encoders/encoders.ts
+++ b/src/lib/routes/acs/encoders/encoders.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { AcsEncoder } from 'lib/resources/acs-encoder.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
@@ -174,17 +173,13 @@ export class SeamHttpAcsEncoders {
     parameters: AcsEncodersEncodeCredentialParameters,
     options: AcsEncodersEncodeCredentialOptions = {},
   ): AcsEncodersEncodeCredentialRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/encode_credential',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/encode_credential',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -201,14 +196,13 @@ export class SeamHttpAcsEncoders {
     parameters: AcsEncodersGetParameters,
     options: AcsEncodersGetOptions = {},
   ): AcsEncodersGetRequest {
-    assertValidRequestParameters(parameters, '/acs/encoders/get', true, [
-      'acs_encoder_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: 'acs_encoder',
       options,
     })
@@ -221,12 +215,13 @@ export class SeamHttpAcsEncoders {
     parameters?: AcsEncodersListParameters,
     options: AcsEncodersListOptions = {},
   ): AcsEncodersListRequest {
-    assertValidRequestParameters(parameters, '/acs/encoders/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_encoders',
       options,
     })
@@ -239,17 +234,13 @@ export class SeamHttpAcsEncoders {
     parameters: AcsEncodersScanCredentialParameters,
     options: AcsEncodersScanCredentialOptions = {},
   ): AcsEncodersScanCredentialRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/scan_credential',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/scan_credential',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -266,17 +257,13 @@ export class SeamHttpAcsEncoders {
     parameters: AcsEncodersScanToAssignCredentialParameters,
     options: AcsEncodersScanToAssignCredentialOptions = {},
   ): AcsEncodersScanToAssignCredentialRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/scan_to_assign_credential',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/scan_to_assign_credential',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/acs/encoders/simulate/simulate.ts
+++ b/src/lib/routes/acs/encoders/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -165,17 +164,13 @@ export class SeamHttpAcsEncodersSimulate {
     parameters: AcsEncodersSimulateNextCredentialEncodeWillFailParameters,
     options: AcsEncodersSimulateNextCredentialEncodeWillFailOptions = {},
   ): AcsEncodersSimulateNextCredentialEncodeWillFailRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/simulate/next_credential_encode_will_fail',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/simulate/next_credential_encode_will_fail',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: undefined,
       options,
     })
@@ -188,17 +183,13 @@ export class SeamHttpAcsEncodersSimulate {
     parameters: AcsEncodersSimulateNextCredentialEncodeWillSucceedParameters,
     options: AcsEncodersSimulateNextCredentialEncodeWillSucceedOptions = {},
   ): AcsEncodersSimulateNextCredentialEncodeWillSucceedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/simulate/next_credential_encode_will_succeed',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/simulate/next_credential_encode_will_succeed',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: undefined,
       options,
     })
@@ -211,17 +202,13 @@ export class SeamHttpAcsEncodersSimulate {
     parameters: AcsEncodersSimulateNextCredentialScanWillFailParameters,
     options: AcsEncodersSimulateNextCredentialScanWillFailOptions = {},
   ): AcsEncodersSimulateNextCredentialScanWillFailRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/simulate/next_credential_scan_will_fail',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/simulate/next_credential_scan_will_fail',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: undefined,
       options,
     })
@@ -234,17 +221,13 @@ export class SeamHttpAcsEncodersSimulate {
     parameters: AcsEncodersSimulateNextCredentialScanWillSucceedParameters,
     options: AcsEncodersSimulateNextCredentialScanWillSucceedOptions = {},
   ): AcsEncodersSimulateNextCredentialScanWillSucceedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/encoders/simulate/next_credential_scan_will_succeed',
-      true,
-      ['acs_encoder_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/encoders/simulate/next_credential_scan_will_succeed',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_encoder_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/entrances/entrances.ts
+++ b/src/lib/routes/acs/entrances/entrances.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { AcsCredential } from 'lib/resources/acs-credential.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
@@ -169,14 +168,13 @@ export class SeamHttpAcsEntrances {
     parameters: AcsEntrancesGetParameters,
     options: AcsEntrancesGetOptions = {},
   ): AcsEntrancesGetRequest {
-    assertValidRequestParameters(parameters, '/acs/entrances/get', true, [
-      'acs_entrance_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/entrances/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_entrance_id'],
       responseKey: 'acs_entrance',
       options,
     })
@@ -189,17 +187,13 @@ export class SeamHttpAcsEntrances {
     parameters: AcsEntrancesGrantAccessParameters,
     options: AcsEntrancesGrantAccessOptions = {},
   ): AcsEntrancesGrantAccessRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/entrances/grant_access',
-      true,
-      ['acs_entrance_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/entrances/grant_access',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_entrance_id'],
       responseKey: undefined,
       options,
     })
@@ -212,12 +206,13 @@ export class SeamHttpAcsEntrances {
     parameters?: AcsEntrancesListParameters,
     options: AcsEntrancesListOptions = {},
   ): AcsEntrancesListRequest {
-    assertValidRequestParameters(parameters, '/acs/entrances/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/entrances/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_entrances',
       options,
     })
@@ -230,17 +225,13 @@ export class SeamHttpAcsEntrances {
     parameters: AcsEntrancesListCredentialsWithAccessParameters,
     options: AcsEntrancesListCredentialsWithAccessOptions = {},
   ): AcsEntrancesListCredentialsWithAccessRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/entrances/list_credentials_with_access',
-      true,
-      ['acs_entrance_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/entrances/list_credentials_with_access',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_entrance_id'],
       responseKey: 'acs_credentials',
       options,
     })
@@ -253,15 +244,13 @@ export class SeamHttpAcsEntrances {
     parameters: AcsEntrancesUnlockParameters,
     options: AcsEntrancesUnlockOptions = {},
   ): AcsEntrancesUnlockRequest {
-    assertValidRequestParameters(parameters, '/acs/entrances/unlock', true, [
-      'acs_credential_id',
-      'acs_entrance_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/entrances/unlock',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_credential_id', 'acs_entrance_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/acs/systems/systems.ts
+++ b/src/lib/routes/acs/systems/systems.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { AcsSystem } from 'lib/resources/acs-system.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,14 +165,13 @@ export class SeamHttpAcsSystems {
     parameters: AcsSystemsGetParameters,
     options: AcsSystemsGetOptions = {},
   ): AcsSystemsGetRequest {
-    assertValidRequestParameters(parameters, '/acs/systems/get', true, [
-      'acs_system_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/systems/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_system_id'],
       responseKey: 'acs_system',
       options,
     })
@@ -188,12 +186,13 @@ export class SeamHttpAcsSystems {
     parameters?: AcsSystemsListParameters,
     options: AcsSystemsListOptions = {},
   ): AcsSystemsListRequest {
-    assertValidRequestParameters(parameters, '/acs/systems/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/systems/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_systems',
       options,
     })
@@ -208,17 +207,13 @@ export class SeamHttpAcsSystems {
     parameters: AcsSystemsListCompatibleCredentialManagerAcsSystemsParameters,
     options: AcsSystemsListCompatibleCredentialManagerAcsSystemsOptions = {},
   ): AcsSystemsListCompatibleCredentialManagerAcsSystemsRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/systems/list_compatible_credential_manager_acs_systems',
-      true,
-      ['acs_system_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/systems/list_compatible_credential_manager_acs_systems',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_system_id'],
       responseKey: 'acs_systems',
       options,
     })
@@ -231,17 +226,13 @@ export class SeamHttpAcsSystems {
     parameters: AcsSystemsReportDevicesParameters,
     options: AcsSystemsReportDevicesOptions = {},
   ): AcsSystemsReportDevicesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/systems/report_devices',
-      true,
-      ['acs_system_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/systems/report_devices',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_system_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/users/users.ts
+++ b/src/lib/routes/acs/users/users.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { AcsUser } from 'lib/resources/acs-user.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -170,17 +167,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersAddToAccessGroupParameters,
     options: AcsUsersAddToAccessGroupOptions = {},
   ): AcsUsersAddToAccessGroupRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/users/add_to_access_group',
-      true,
-      ['acs_access_group_id', 'acs_user_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/add_to_access_group',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id', 'acs_user_id'],
       responseKey: undefined,
       options,
     })
@@ -193,15 +186,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersCreateParameters,
     options: AcsUsersCreateOptions = {},
   ): AcsUsersCreateRequest {
-    assertValidRequestParameters(parameters, '/acs/users/create', true, [
-      'acs_system_id',
-      'full_name',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_system_id', 'full_name'],
       responseKey: 'acs_user',
       options,
     })
@@ -214,12 +205,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersDeleteParameters,
     options: AcsUsersDeleteOptions = {},
   ): AcsUsersDeleteRequest {
-    assertValidRequestParameters(parameters, '/acs/users/delete', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -232,12 +224,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersGetParameters,
     options: AcsUsersGetOptions = {},
   ): AcsUsersGetRequest {
-    assertValidRequestParameters(parameters, '/acs/users/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'acs_user',
       options,
     })
@@ -250,12 +243,13 @@ export class SeamHttpAcsUsers {
     parameters?: AcsUsersListParameters,
     options: AcsUsersListOptions = {},
   ): AcsUsersListRequest {
-    assertValidRequestParameters(parameters, '/acs/users/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'acs_users',
       options,
     })
@@ -268,17 +262,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersListAccessibleEntrancesParameters,
     options: AcsUsersListAccessibleEntrancesOptions = {},
   ): AcsUsersListAccessibleEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/users/list_accessible_entrances',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/list_accessible_entrances',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'acs_entrances',
       options,
     })
@@ -291,17 +281,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersRemoveFromAccessGroupParameters,
     options: AcsUsersRemoveFromAccessGroupOptions = {},
   ): AcsUsersRemoveFromAccessGroupRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/users/remove_from_access_group',
-      true,
-      ['acs_access_group_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/remove_from_access_group',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_access_group_id'],
       responseKey: undefined,
       options,
     })
@@ -314,17 +300,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersRevokeAccessToAllEntrancesParameters,
     options: AcsUsersRevokeAccessToAllEntrancesOptions = {},
   ): AcsUsersRevokeAccessToAllEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/acs/users/revoke_access_to_all_entrances',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/revoke_access_to_all_entrances',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -337,12 +319,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersSuspendParameters,
     options: AcsUsersSuspendOptions = {},
   ): AcsUsersSuspendRequest {
-    assertValidRequestParameters(parameters, '/acs/users/suspend', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/suspend',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -355,12 +338,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersUnsuspendParameters,
     options: AcsUsersUnsuspendOptions = {},
   ): AcsUsersUnsuspendRequest {
-    assertValidRequestParameters(parameters, '/acs/users/unsuspend', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/unsuspend',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -373,12 +357,13 @@ export class SeamHttpAcsUsers {
     parameters: AcsUsersUpdateParameters,
     options: AcsUsersUpdateOptions = {},
   ): AcsUsersUpdateRequest {
-    assertValidRequestParameters(parameters, '/acs/users/update', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/acs/users/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/action-attempts/action-attempts.ts
+++ b/src/lib/routes/action-attempts/action-attempts.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,14 +165,13 @@ export class SeamHttpActionAttempts {
     parameters: ActionAttemptsGetParameters,
     options: ActionAttemptsGetOptions = {},
   ): ActionAttemptsGetRequest {
-    assertValidRequestParameters(parameters, '/action_attempts/get', true, [
-      'action_attempt_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/action_attempts/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['action_attempt_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -190,12 +188,13 @@ export class SeamHttpActionAttempts {
     parameters?: ActionAttemptsListParameters,
     options: ActionAttemptsListOptions = {},
   ): ActionAttemptsListRequest {
-    assertValidRequestParameters(parameters, '/action_attempts/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/action_attempts/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'action_attempts',
       options,
     })

--- a/src/lib/routes/client-sessions/client-sessions.ts
+++ b/src/lib/routes/client-sessions/client-sessions.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { ClientSession } from 'lib/resources/client-session.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -168,17 +165,13 @@ export class SeamHttpClientSessions {
     parameters?: ClientSessionsCreateParameters,
     options: ClientSessionsCreateOptions = {},
   ): ClientSessionsCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/client_sessions/create',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/create',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -191,14 +184,13 @@ export class SeamHttpClientSessions {
     parameters: ClientSessionsDeleteParameters,
     options: ClientSessionsDeleteOptions = {},
   ): ClientSessionsDeleteRequest {
-    assertValidRequestParameters(parameters, '/client_sessions/delete', true, [
-      'client_session_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['client_session_id'],
       responseKey: undefined,
       options,
     })
@@ -211,12 +203,13 @@ export class SeamHttpClientSessions {
     parameters?: ClientSessionsGetParameters,
     options: ClientSessionsGetOptions = {},
   ): ClientSessionsGetRequest {
-    assertValidRequestParameters(parameters, '/client_sessions/get', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -229,17 +222,13 @@ export class SeamHttpClientSessions {
     parameters?: ClientSessionsGetOrCreateParameters,
     options: ClientSessionsGetOrCreateOptions = {},
   ): ClientSessionsGetOrCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/client_sessions/get_or_create',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/get_or_create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -252,17 +241,13 @@ export class SeamHttpClientSessions {
     parameters: ClientSessionsGrantAccessParameters,
     options: ClientSessionsGrantAccessOptions = {},
   ): ClientSessionsGrantAccessRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/client_sessions/grant_access',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/grant_access',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -275,12 +260,13 @@ export class SeamHttpClientSessions {
     parameters?: ClientSessionsListParameters,
     options: ClientSessionsListOptions = {},
   ): ClientSessionsListRequest {
-    assertValidRequestParameters(parameters, '/client_sessions/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'client_sessions',
       options,
     })
@@ -295,14 +281,13 @@ export class SeamHttpClientSessions {
     parameters: ClientSessionsRevokeParameters,
     options: ClientSessionsRevokeOptions = {},
   ): ClientSessionsRevokeRequest {
-    assertValidRequestParameters(parameters, '/client_sessions/revoke', true, [
-      'client_session_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/client_sessions/revoke',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['client_session_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/connect-webviews/connect-webviews.ts
+++ b/src/lib/routes/connect-webviews/connect-webviews.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ConnectWebview } from 'lib/resources/connect-webview.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -172,17 +171,13 @@ export class SeamHttpConnectWebviews {
     parameters?: ConnectWebviewsCreateParameters,
     options: ConnectWebviewsCreateOptions = {},
   ): ConnectWebviewsCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connect_webviews/create',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connect_webviews/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'connect_webview',
       options,
     })
@@ -197,14 +192,13 @@ export class SeamHttpConnectWebviews {
     parameters: ConnectWebviewsDeleteParameters,
     options: ConnectWebviewsDeleteOptions = {},
   ): ConnectWebviewsDeleteRequest {
-    assertValidRequestParameters(parameters, '/connect_webviews/delete', true, [
-      'connect_webview_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/connect_webviews/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connect_webview_id'],
       responseKey: undefined,
       options,
     })
@@ -219,14 +213,13 @@ export class SeamHttpConnectWebviews {
     parameters: ConnectWebviewsGetParameters,
     options: ConnectWebviewsGetOptions = {},
   ): ConnectWebviewsGetRequest {
-    assertValidRequestParameters(parameters, '/connect_webviews/get', true, [
-      'connect_webview_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/connect_webviews/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connect_webview_id'],
       responseKey: 'connect_webview',
       options,
     })
@@ -239,17 +232,13 @@ export class SeamHttpConnectWebviews {
     parameters?: ConnectWebviewsListParameters,
     options: ConnectWebviewsListOptions = {},
   ): ConnectWebviewsListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connect_webviews/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connect_webviews/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'connect_webviews',
       options,
     })

--- a/src/lib/routes/connected-accounts/connected-accounts.ts
+++ b/src/lib/routes/connected-accounts/connected-accounts.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { ConnectedAccount } from 'lib/resources/connected-account.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -182,17 +179,13 @@ export class SeamHttpConnectedAccounts {
     parameters: ConnectedAccountsDeleteParameters,
     options: ConnectedAccountsDeleteOptions = {},
   ): ConnectedAccountsDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connected_accounts/delete',
-      true,
-      ['connected_account_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id'],
       responseKey: undefined,
       options,
     })
@@ -205,17 +198,13 @@ export class SeamHttpConnectedAccounts {
     parameters: ConnectedAccountsGetParameters,
     options: ConnectedAccountsGetOptions = {},
   ): ConnectedAccountsGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connected_accounts/get',
-      true,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'connected_account',
       options,
     })
@@ -228,17 +217,13 @@ export class SeamHttpConnectedAccounts {
     parameters?: ConnectedAccountsListParameters,
     options: ConnectedAccountsListOptions = {},
   ): ConnectedAccountsListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connected_accounts/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'connected_accounts',
       options,
     })
@@ -251,14 +236,13 @@ export class SeamHttpConnectedAccounts {
     parameters: ConnectedAccountsSyncParameters,
     options: ConnectedAccountsSyncOptions = {},
   ): ConnectedAccountsSyncRequest {
-    assertValidRequestParameters(parameters, '/connected_accounts/sync', true, [
-      'connected_account_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/sync',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id'],
       responseKey: undefined,
       options,
     })
@@ -271,17 +255,13 @@ export class SeamHttpConnectedAccounts {
     parameters: ConnectedAccountsUpdateParameters,
     options: ConnectedAccountsUpdateOptions = {},
   ): ConnectedAccountsUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connected_accounts/update',
-      true,
-      ['connected_account_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/connected-accounts/simulate/simulate.ts
+++ b/src/lib/routes/connected-accounts/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -168,17 +167,13 @@ export class SeamHttpConnectedAccountsSimulate {
     parameters: ConnectedAccountsSimulateDisconnectParameters,
     options: ConnectedAccountsSimulateDisconnectOptions = {},
   ): ConnectedAccountsSimulateDisconnectRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/connected_accounts/simulate/disconnect',
-      true,
-      ['connected_account_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/connected_accounts/simulate/disconnect',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/customers/customers.ts
+++ b/src/lib/routes/customers/customers.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { CustomerPortal } from 'lib/resources/customer-portal.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,13 @@ export class SeamHttpCustomers {
     parameters?: CustomersCreatePortalParameters,
     options: CustomersCreatePortalOptions = {},
   ): CustomersCreatePortalRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/customers/create_portal',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/customers/create_portal',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'customer_portal',
       options,
     })
@@ -190,17 +185,13 @@ export class SeamHttpCustomers {
     parameters?: CustomersDeleteDataParameters,
     options: CustomersDeleteDataOptions = {},
   ): CustomersDeleteDataRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/customers/delete_data',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/customers/delete_data',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -213,14 +204,13 @@ export class SeamHttpCustomers {
     parameters: CustomersPushDataParameters,
     options: CustomersPushDataOptions = {},
   ): CustomersPushDataRequest {
-    assertValidRequestParameters(parameters, '/customers/push_data', true, [
-      'customer_key',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/customers/push_data',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['customer_key'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/devices/devices.ts
+++ b/src/lib/routes/devices/devices.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { Device } from 'lib/resources/device.js'
 import type { DeviceProvider } from 'lib/resources/device-provider.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -183,12 +180,13 @@ export class SeamHttpDevices {
     parameters: DevicesGetParameters,
     options: DevicesGetOptions = {},
   ): DevicesGetRequest {
-    assertValidRequestParameters(parameters, '/devices/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'device',
       options,
     })
@@ -201,12 +199,13 @@ export class SeamHttpDevices {
     parameters?: DevicesListParameters,
     options: DevicesListOptions = {},
   ): DevicesListRequest {
-    assertValidRequestParameters(parameters, '/devices/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -223,17 +222,13 @@ export class SeamHttpDevices {
     parameters?: DevicesListDeviceProvidersParameters,
     options: DevicesListDeviceProvidersOptions = {},
   ): DevicesListDeviceProvidersRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/list_device_providers',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/list_device_providers',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'device_providers',
       options,
     })
@@ -246,17 +241,13 @@ export class SeamHttpDevices {
     parameters: DevicesReportProviderMetadataParameters,
     options: DevicesReportProviderMetadataOptions = {},
   ): DevicesReportProviderMetadataRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/report_provider_metadata',
-      true,
-      ['devices'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/report_provider_metadata',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['devices'],
       responseKey: undefined,
       options,
     })
@@ -271,14 +262,13 @@ export class SeamHttpDevices {
     parameters: DevicesUpdateParameters,
     options: DevicesUpdateOptions = {},
   ): DevicesUpdateRequest {
-    assertValidRequestParameters(parameters, '/devices/update', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/devices/simulate/simulate.ts
+++ b/src/lib/routes/devices/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -165,17 +164,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulateConnectParameters,
     options: DevicesSimulateConnectOptions = {},
   ): DevicesSimulateConnectRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/simulate/connect',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/connect',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -191,17 +186,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulateConnectToHubParameters,
     options: DevicesSimulateConnectToHubOptions = {},
   ): DevicesSimulateConnectToHubRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/simulate/connect_to_hub',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/connect_to_hub',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -214,17 +205,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulateDisconnectParameters,
     options: DevicesSimulateDisconnectOptions = {},
   ): DevicesSimulateDisconnectRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/simulate/disconnect',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/disconnect',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -241,17 +228,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulateDisconnectFromHubParameters,
     options: DevicesSimulateDisconnectFromHubOptions = {},
   ): DevicesSimulateDisconnectFromHubRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/simulate/disconnect_from_hub',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/disconnect_from_hub',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -266,17 +249,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulatePaidSubscriptionParameters,
     options: DevicesSimulatePaidSubscriptionOptions = {},
   ): DevicesSimulatePaidSubscriptionRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/simulate/paid_subscription',
-      true,
-      ['device_id', 'is_expired'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/paid_subscription',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'is_expired'],
       responseKey: undefined,
       options,
     })
@@ -289,14 +268,13 @@ export class SeamHttpDevicesSimulate {
     parameters: DevicesSimulateRemoveParameters,
     options: DevicesSimulateRemoveOptions = {},
   ): DevicesSimulateRemoveRequest {
-    assertValidRequestParameters(parameters, '/devices/simulate/remove', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/simulate/remove',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/devices/unmanaged/unmanaged.ts
+++ b/src/lib/routes/devices/unmanaged/unmanaged.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { UnmanagedDevice } from 'lib/resources/unmanaged-device.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -173,12 +170,13 @@ export class SeamHttpDevicesUnmanaged {
     parameters: DevicesUnmanagedGetParameters,
     options: DevicesUnmanagedGetOptions = {},
   ): DevicesUnmanagedGetRequest {
-    assertValidRequestParameters(parameters, '/devices/unmanaged/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/unmanaged/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'device',
       options,
     })
@@ -193,17 +191,13 @@ export class SeamHttpDevicesUnmanaged {
     parameters?: DevicesUnmanagedListParameters,
     options: DevicesUnmanagedListOptions = {},
   ): DevicesUnmanagedListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/unmanaged/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/unmanaged/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -218,17 +212,13 @@ export class SeamHttpDevicesUnmanaged {
     parameters: DevicesUnmanagedUpdateParameters,
     options: DevicesUnmanagedUpdateOptions = {},
   ): DevicesUnmanagedUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/devices/unmanaged/update',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/devices/unmanaged/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/events/events.ts
+++ b/src/lib/routes/events/events.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { SeamEvent } from 'lib/resources/event.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -169,12 +166,13 @@ export class SeamHttpEvents {
     parameters: EventsGetParameters,
     options: EventsGetOptions = {},
   ): EventsGetRequest {
-    assertValidRequestParameters(parameters, '/events/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/events/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'event',
       options,
     })
@@ -187,12 +185,13 @@ export class SeamHttpEvents {
     parameters: EventsListParameters,
     options: EventsListOptions = {},
   ): EventsListRequest {
-    assertValidRequestParameters(parameters, '/events/list', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/events/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'events',
       options,
     })

--- a/src/lib/routes/instant-keys/instant-keys.ts
+++ b/src/lib/routes/instant-keys/instant-keys.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { InstantKey } from 'lib/resources/instant-key.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -169,14 +166,13 @@ export class SeamHttpInstantKeys {
     parameters: InstantKeysDeleteParameters,
     options: InstantKeysDeleteOptions = {},
   ): InstantKeysDeleteRequest {
-    assertValidRequestParameters(parameters, '/instant_keys/delete', true, [
-      'instant_key_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/instant_keys/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['instant_key_id'],
       responseKey: undefined,
       options,
     })
@@ -189,12 +185,13 @@ export class SeamHttpInstantKeys {
     parameters: InstantKeysGetParameters,
     options: InstantKeysGetOptions = {},
   ): InstantKeysGetRequest {
-    assertValidRequestParameters(parameters, '/instant_keys/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/instant_keys/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'instant_key',
       options,
     })
@@ -207,12 +204,13 @@ export class SeamHttpInstantKeys {
     parameters?: InstantKeysListParameters,
     options: InstantKeysListOptions = {},
   ): InstantKeysListRequest {
-    assertValidRequestParameters(parameters, '/instant_keys/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/instant_keys/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'instant_keys',
       options,
     })

--- a/src/lib/routes/locks/locks.ts
+++ b/src/lib/routes/locks/locks.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
@@ -177,17 +174,13 @@ export class SeamHttpLocks {
     parameters: LocksConfigureAutoLockParameters,
     options: LocksConfigureAutoLockOptions = {},
   ): LocksConfigureAutoLockRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/locks/configure_auto_lock',
-      true,
-      ['auto_lock_enabled', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/configure_auto_lock',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['auto_lock_enabled', 'device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -205,12 +198,13 @@ export class SeamHttpLocks {
     parameters: LocksGetParameters,
     options: LocksGetOptions = {},
   ): LocksGetRequest {
-    assertValidRequestParameters(parameters, '/locks/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'device',
       options,
     })
@@ -223,12 +217,13 @@ export class SeamHttpLocks {
     parameters?: LocksListParameters,
     options: LocksListOptions = {},
   ): LocksListRequest {
-    assertValidRequestParameters(parameters, '/locks/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -241,14 +236,13 @@ export class SeamHttpLocks {
     parameters: LocksLockDoorParameters,
     options: LocksLockDoorOptions = {},
   ): LocksLockDoorRequest {
-    assertValidRequestParameters(parameters, '/locks/lock_door', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/lock_door',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -265,14 +259,13 @@ export class SeamHttpLocks {
     parameters: LocksUnlockDoorParameters,
     options: LocksUnlockDoorOptions = {},
   ): LocksUnlockDoorRequest {
-    assertValidRequestParameters(parameters, '/locks/unlock_door', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/unlock_door',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/locks/simulate/simulate.ts
+++ b/src/lib/routes/locks/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -167,17 +166,13 @@ export class SeamHttpLocksSimulate {
     parameters: LocksSimulateKeypadCodeEntryParameters,
     options: LocksSimulateKeypadCodeEntryOptions = {},
   ): LocksSimulateKeypadCodeEntryRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/locks/simulate/keypad_code_entry',
-      true,
-      ['code', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/simulate/keypad_code_entry',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['code', 'device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -194,17 +189,13 @@ export class SeamHttpLocksSimulate {
     parameters: LocksSimulateManualLockViaKeypadParameters,
     options: LocksSimulateManualLockViaKeypadOptions = {},
   ): LocksSimulateManualLockViaKeypadRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/locks/simulate/manual_lock_via_keypad',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/locks/simulate/manual_lock_via_keypad',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/noise-sensors/noise-sensors.ts
+++ b/src/lib/routes/noise-sensors/noise-sensors.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -180,12 +179,13 @@ export class SeamHttpNoiseSensors {
     parameters?: NoiseSensorsListParameters,
     options: NoiseSensorsListOptions = {},
   ): NoiseSensorsListRequest {
-    assertValidRequestParameters(parameters, '/noise_sensors/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'devices',
       options,
     })

--- a/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
+++ b/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { NoiseThreshold } from 'lib/resources/noise-threshold.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -169,17 +168,13 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     parameters: NoiseSensorsNoiseThresholdsCreateParameters,
     options: NoiseSensorsNoiseThresholdsCreateOptions = {},
   ): NoiseSensorsNoiseThresholdsCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/noise_thresholds/create',
-      true,
-      ['device_id', 'ends_daily_at', 'starts_daily_at'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/noise_thresholds/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'ends_daily_at', 'starts_daily_at'],
       responseKey: 'noise_threshold',
       options,
     })
@@ -192,17 +187,13 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     parameters: NoiseSensorsNoiseThresholdsDeleteParameters,
     options: NoiseSensorsNoiseThresholdsDeleteOptions = {},
   ): NoiseSensorsNoiseThresholdsDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/noise_thresholds/delete',
-      true,
-      ['device_id', 'noise_threshold_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/noise_thresholds/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'noise_threshold_id'],
       responseKey: undefined,
       options,
     })
@@ -215,17 +206,13 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     parameters: NoiseSensorsNoiseThresholdsGetParameters,
     options: NoiseSensorsNoiseThresholdsGetOptions = {},
   ): NoiseSensorsNoiseThresholdsGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/noise_thresholds/get',
-      true,
-      ['noise_threshold_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/noise_thresholds/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['noise_threshold_id'],
       responseKey: 'noise_threshold',
       options,
     })
@@ -238,17 +225,13 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     parameters: NoiseSensorsNoiseThresholdsListParameters,
     options: NoiseSensorsNoiseThresholdsListOptions = {},
   ): NoiseSensorsNoiseThresholdsListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/noise_thresholds/list',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/noise_thresholds/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'noise_thresholds',
       options,
     })
@@ -261,17 +244,13 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
     parameters: NoiseSensorsNoiseThresholdsUpdateParameters,
     options: NoiseSensorsNoiseThresholdsUpdateOptions = {},
   ): NoiseSensorsNoiseThresholdsUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/noise_thresholds/update',
-      true,
-      ['device_id', 'noise_threshold_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/noise_thresholds/update',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'noise_threshold_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/noise-sensors/simulate/simulate.ts
+++ b/src/lib/routes/noise-sensors/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -165,17 +164,13 @@ export class SeamHttpNoiseSensorsSimulate {
     parameters: NoiseSensorsSimulateTriggerNoiseThresholdParameters,
     options: NoiseSensorsSimulateTriggerNoiseThresholdOptions = {},
   ): NoiseSensorsSimulateTriggerNoiseThresholdRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/noise_sensors/simulate/trigger_noise_threshold',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/noise_sensors/simulate/trigger_noise_threshold',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/phones/phones.ts
+++ b/src/lib/routes/phones/phones.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { Phone } from 'lib/resources/phone.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -172,14 +171,13 @@ export class SeamHttpPhones {
     parameters: PhonesDeactivateParameters,
     options: PhonesDeactivateOptions = {},
   ): PhonesDeactivateRequest {
-    assertValidRequestParameters(parameters, '/phones/deactivate', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/phones/deactivate',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -192,12 +190,13 @@ export class SeamHttpPhones {
     parameters: PhonesGetParameters,
     options: PhonesGetOptions = {},
   ): PhonesGetRequest {
-    assertValidRequestParameters(parameters, '/phones/get', true, ['device_id'])
-
     return new SeamHttpRequest(this, {
       pathname: '/phones/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'phone',
       options,
     })
@@ -210,12 +209,13 @@ export class SeamHttpPhones {
     parameters?: PhonesListParameters,
     options: PhonesListOptions = {},
   ): PhonesListRequest {
-    assertValidRequestParameters(parameters, '/phones/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/phones/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'phones',
       options,
     })

--- a/src/lib/routes/phones/simulate/simulate.ts
+++ b/src/lib/routes/phones/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { Phone } from 'lib/resources/phone.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,13 @@ export class SeamHttpPhonesSimulate {
     parameters: PhonesSimulateCreateSandboxPhoneParameters,
     options: PhonesSimulateCreateSandboxPhoneOptions = {},
   ): PhonesSimulateCreateSandboxPhoneRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/phones/simulate/create_sandbox_phone',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/phones/simulate/create_sandbox_phone',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'phone',
       options,
     })

--- a/src/lib/routes/spaces/spaces.ts
+++ b/src/lib/routes/spaces/spaces.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { Batch } from 'lib/resources/batch.js'
 import type { Space } from 'lib/resources/space.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
@@ -170,17 +167,13 @@ export class SeamHttpSpaces {
     parameters: SpacesAddAcsEntrancesParameters,
     options: SpacesAddAcsEntrancesOptions = {},
   ): SpacesAddAcsEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/spaces/add_acs_entrances',
-      true,
-      ['acs_entrance_ids', 'space_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/add_acs_entrances',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_entrance_ids', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -193,17 +186,13 @@ export class SeamHttpSpaces {
     parameters: SpacesAddConnectedAccountParameters,
     options: SpacesAddConnectedAccountOptions = {},
   ): SpacesAddConnectedAccountRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/spaces/add_connected_account',
-      true,
-      ['connected_account_id', 'space_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/add_connected_account',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -216,15 +205,13 @@ export class SeamHttpSpaces {
     parameters: SpacesAddDevicesParameters,
     options: SpacesAddDevicesOptions = {},
   ): SpacesAddDevicesRequest {
-    assertValidRequestParameters(parameters, '/spaces/add_devices', true, [
-      'device_ids',
-      'space_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/add_devices',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_ids', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -237,12 +224,13 @@ export class SeamHttpSpaces {
     parameters: SpacesCreateParameters,
     options: SpacesCreateOptions = {},
   ): SpacesCreateRequest {
-    assertValidRequestParameters(parameters, '/spaces/create', true, ['name'])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['name'],
       responseKey: 'space',
       options,
     })
@@ -255,14 +243,13 @@ export class SeamHttpSpaces {
     parameters: SpacesDeleteParameters,
     options: SpacesDeleteOptions = {},
   ): SpacesDeleteRequest {
-    assertValidRequestParameters(parameters, '/spaces/delete', true, [
-      'space_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['space_id'],
       responseKey: undefined,
       options,
     })
@@ -275,12 +262,13 @@ export class SeamHttpSpaces {
     parameters: SpacesGetParameters,
     options: SpacesGetOptions = {},
   ): SpacesGetRequest {
-    assertValidRequestParameters(parameters, '/spaces/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'space',
       options,
     })
@@ -293,12 +281,13 @@ export class SeamHttpSpaces {
     parameters: SpacesGetRelatedParameters,
     options: SpacesGetRelatedOptions = {},
   ): SpacesGetRelatedRequest {
-    assertValidRequestParameters(parameters, '/spaces/get_related', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/get_related',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'batch',
       options,
     })
@@ -311,12 +300,13 @@ export class SeamHttpSpaces {
     parameters?: SpacesListParameters,
     options: SpacesListOptions = {},
   ): SpacesListRequest {
-    assertValidRequestParameters(parameters, '/spaces/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'spaces',
       options,
     })
@@ -329,17 +319,13 @@ export class SeamHttpSpaces {
     parameters: SpacesRemoveAcsEntrancesParameters,
     options: SpacesRemoveAcsEntrancesOptions = {},
   ): SpacesRemoveAcsEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/spaces/remove_acs_entrances',
-      true,
-      ['acs_entrance_ids', 'space_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/remove_acs_entrances',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_entrance_ids', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -352,17 +338,13 @@ export class SeamHttpSpaces {
     parameters: SpacesRemoveConnectedAccountParameters,
     options: SpacesRemoveConnectedAccountOptions = {},
   ): SpacesRemoveConnectedAccountRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/spaces/remove_connected_account',
-      true,
-      ['connected_account_id', 'space_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/remove_connected_account',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['connected_account_id', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -375,15 +357,13 @@ export class SeamHttpSpaces {
     parameters: SpacesRemoveDevicesParameters,
     options: SpacesRemoveDevicesOptions = {},
   ): SpacesRemoveDevicesRequest {
-    assertValidRequestParameters(parameters, '/spaces/remove_devices', true, [
-      'device_ids',
-      'space_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/remove_devices',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_ids', 'space_id'],
       responseKey: undefined,
       options,
     })
@@ -396,12 +376,13 @@ export class SeamHttpSpaces {
     parameters?: SpacesUpdateParameters,
     options: SpacesUpdateOptions = {},
   ): SpacesUpdateRequest {
-    assertValidRequestParameters(parameters, '/spaces/update', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/spaces/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'space',
       options,
     })

--- a/src/lib/routes/thermostats/daily-programs/daily-programs.ts
+++ b/src/lib/routes/thermostats/daily-programs/daily-programs.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { ThermostatDailyProgram } from 'lib/resources/thermostat-daily-program.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
@@ -171,17 +170,13 @@ export class SeamHttpThermostatsDailyPrograms {
     parameters: ThermostatsDailyProgramsCreateParameters,
     options: ThermostatsDailyProgramsCreateOptions = {},
   ): ThermostatsDailyProgramsCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/daily_programs/create',
-      true,
-      ['device_id', 'name', 'periods'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/daily_programs/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'name', 'periods'],
       responseKey: 'thermostat_daily_program',
       options,
     })
@@ -194,17 +189,13 @@ export class SeamHttpThermostatsDailyPrograms {
     parameters: ThermostatsDailyProgramsDeleteParameters,
     options: ThermostatsDailyProgramsDeleteOptions = {},
   ): ThermostatsDailyProgramsDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/daily_programs/delete',
-      true,
-      ['thermostat_daily_program_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/daily_programs/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['thermostat_daily_program_id'],
       responseKey: undefined,
       options,
     })
@@ -217,17 +208,17 @@ export class SeamHttpThermostatsDailyPrograms {
     parameters: ThermostatsDailyProgramsUpdateParameters,
     options: ThermostatsDailyProgramsUpdateOptions = {},
   ): ThermostatsDailyProgramsUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/daily_programs/update',
-      true,
-      ['name', 'periods', 'thermostat_daily_program_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/daily_programs/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [
+        'name',
+        'periods',
+        'thermostat_daily_program_id',
+      ],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/thermostats/schedules/schedules.ts
+++ b/src/lib/routes/thermostats/schedules/schedules.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ThermostatSchedule } from 'lib/resources/thermostat-schedule.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,17 +165,18 @@ export class SeamHttpThermostatsSchedules {
     parameters: ThermostatsSchedulesCreateParameters,
     options: ThermostatsSchedulesCreateOptions = {},
   ): ThermostatsSchedulesCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/schedules/create',
-      true,
-      ['climate_preset_key', 'device_id', 'ends_at', 'starts_at'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/schedules/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [
+        'climate_preset_key',
+        'device_id',
+        'ends_at',
+        'starts_at',
+      ],
       responseKey: 'thermostat_schedule',
       options,
     })
@@ -189,17 +189,13 @@ export class SeamHttpThermostatsSchedules {
     parameters: ThermostatsSchedulesDeleteParameters,
     options: ThermostatsSchedulesDeleteOptions = {},
   ): ThermostatsSchedulesDeleteRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/schedules/delete',
-      true,
-      ['thermostat_schedule_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/schedules/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['thermostat_schedule_id'],
       responseKey: undefined,
       options,
     })
@@ -212,17 +208,13 @@ export class SeamHttpThermostatsSchedules {
     parameters: ThermostatsSchedulesGetParameters,
     options: ThermostatsSchedulesGetOptions = {},
   ): ThermostatsSchedulesGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/schedules/get',
-      true,
-      ['thermostat_schedule_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/schedules/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['thermostat_schedule_id'],
       responseKey: 'thermostat_schedule',
       options,
     })
@@ -235,17 +227,13 @@ export class SeamHttpThermostatsSchedules {
     parameters: ThermostatsSchedulesListParameters,
     options: ThermostatsSchedulesListOptions = {},
   ): ThermostatsSchedulesListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/schedules/list',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/schedules/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'thermostat_schedules',
       options,
     })
@@ -258,17 +246,13 @@ export class SeamHttpThermostatsSchedules {
     parameters: ThermostatsSchedulesUpdateParameters,
     options: ThermostatsSchedulesUpdateOptions = {},
   ): ThermostatsSchedulesUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/schedules/update',
-      true,
-      ['thermostat_schedule_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/schedules/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['thermostat_schedule_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/thermostats/simulate/simulate.ts
+++ b/src/lib/routes/thermostats/simulate/simulate.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
@@ -165,17 +164,13 @@ export class SeamHttpThermostatsSimulate {
     parameters: ThermostatsSimulateHvacModeAdjustedParameters,
     options: ThermostatsSimulateHvacModeAdjustedOptions = {},
   ): ThermostatsSimulateHvacModeAdjustedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/simulate/hvac_mode_adjusted',
-      true,
-      ['device_id', 'hvac_mode'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/simulate/hvac_mode_adjusted',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'hvac_mode'],
       responseKey: undefined,
       options,
     })
@@ -188,17 +183,13 @@ export class SeamHttpThermostatsSimulate {
     parameters: ThermostatsSimulateTemperatureReachedParameters,
     options: ThermostatsSimulateTemperatureReachedOptions = {},
   ): ThermostatsSimulateTemperatureReachedRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/simulate/temperature_reached',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/simulate/temperature_reached',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/thermostats/thermostats.ts
+++ b/src/lib/routes/thermostats/thermostats.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
@@ -187,17 +186,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsActivateClimatePresetParameters,
     options: ThermostatsActivateClimatePresetOptions = {},
   ): ThermostatsActivateClimatePresetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/activate_climate_preset',
-      true,
-      ['climate_preset_key', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/activate_climate_preset',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['climate_preset_key', 'device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -214,14 +209,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsCoolParameters,
     options: ThermostatsCoolOptions = {},
   ): ThermostatsCoolRequest {
-    assertValidRequestParameters(parameters, '/thermostats/cool', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/cool',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -238,17 +232,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsCreateClimatePresetParameters,
     options: ThermostatsCreateClimatePresetOptions = {},
   ): ThermostatsCreateClimatePresetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/create_climate_preset',
-      true,
-      ['climate_preset_key', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/create_climate_preset',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['climate_preset_key', 'device_id'],
       responseKey: undefined,
       options,
     })
@@ -261,17 +251,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsDeleteClimatePresetParameters,
     options: ThermostatsDeleteClimatePresetOptions = {},
   ): ThermostatsDeleteClimatePresetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/delete_climate_preset',
-      true,
-      ['climate_preset_key', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/delete_climate_preset',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['climate_preset_key', 'device_id'],
       responseKey: undefined,
       options,
     })
@@ -284,14 +270,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsHeatParameters,
     options: ThermostatsHeatOptions = {},
   ): ThermostatsHeatRequest {
-    assertValidRequestParameters(parameters, '/thermostats/heat', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/heat',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -308,14 +293,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsHeatCoolParameters,
     options: ThermostatsHeatCoolOptions = {},
   ): ThermostatsHeatCoolRequest {
-    assertValidRequestParameters(parameters, '/thermostats/heat_cool', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/heat_cool',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -332,12 +316,13 @@ export class SeamHttpThermostats {
     parameters?: ThermostatsListParameters,
     options: ThermostatsListOptions = {},
   ): ThermostatsListRequest {
-    assertValidRequestParameters(parameters, '/thermostats/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -350,14 +335,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsOffParameters,
     options: ThermostatsOffOptions = {},
   ): ThermostatsOffRequest {
-    assertValidRequestParameters(parameters, '/thermostats/off', true, [
-      'device_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/off',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -374,17 +358,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsSetFallbackClimatePresetParameters,
     options: ThermostatsSetFallbackClimatePresetOptions = {},
   ): ThermostatsSetFallbackClimatePresetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/set_fallback_climate_preset',
-      true,
-      ['climate_preset_key', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/set_fallback_climate_preset',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['climate_preset_key', 'device_id'],
       responseKey: undefined,
       options,
     })
@@ -397,17 +377,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsSetFanModeParameters,
     options: ThermostatsSetFanModeOptions = {},
   ): ThermostatsSetFanModeRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/set_fan_mode',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/set_fan_mode',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -424,17 +400,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsSetHvacModeParameters,
     options: ThermostatsSetHvacModeOptions = {},
   ): ThermostatsSetHvacModeRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/set_hvac_mode',
-      true,
-      ['device_id', 'hvac_mode_setting'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/set_hvac_mode',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'hvac_mode_setting'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -451,17 +423,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsSetTemperatureThresholdParameters,
     options: ThermostatsSetTemperatureThresholdOptions = {},
   ): ThermostatsSetTemperatureThresholdRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/set_temperature_threshold',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/set_temperature_threshold',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: undefined,
       options,
     })
@@ -474,17 +442,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsUpdateClimatePresetParameters,
     options: ThermostatsUpdateClimatePresetOptions = {},
   ): ThermostatsUpdateClimatePresetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/update_climate_preset',
-      true,
-      ['climate_preset_key', 'device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/update_climate_preset',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['climate_preset_key', 'device_id'],
       responseKey: undefined,
       options,
     })
@@ -497,17 +461,13 @@ export class SeamHttpThermostats {
     parameters: ThermostatsUpdateWeeklyProgramParameters,
     options: ThermostatsUpdateWeeklyProgramOptions = {},
   ): ThermostatsUpdateWeeklyProgramRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/thermostats/update_weekly_program',
-      true,
-      ['device_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/thermostats/update_weekly_program',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id'],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/user-identities/unmanaged/unmanaged.ts
+++ b/src/lib/routes/user-identities/unmanaged/unmanaged.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { UnmanagedUserIdentity } from 'lib/resources/unmanaged-user-identity.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -169,17 +168,13 @@ export class SeamHttpUserIdentitiesUnmanaged {
     parameters: UserIdentitiesUnmanagedGetParameters,
     options: UserIdentitiesUnmanagedGetOptions = {},
   ): UserIdentitiesUnmanagedGetRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/unmanaged/get',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/unmanaged/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'user_identity',
       options,
     })
@@ -192,17 +187,13 @@ export class SeamHttpUserIdentitiesUnmanaged {
     parameters?: UserIdentitiesUnmanagedListParameters,
     options: UserIdentitiesUnmanagedListOptions = {},
   ): UserIdentitiesUnmanagedListRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/unmanaged/list',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/unmanaged/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'user_identities',
       options,
     })
@@ -217,17 +208,13 @@ export class SeamHttpUserIdentitiesUnmanaged {
     parameters: UserIdentitiesUnmanagedUpdateParameters,
     options: UserIdentitiesUnmanagedUpdateOptions = {},
   ): UserIdentitiesUnmanagedUpdateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/unmanaged/update',
-      true,
-      ['is_managed', 'user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/unmanaged/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['is_managed', 'user_identity_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/user-identities/user-identities.ts
+++ b/src/lib/routes/user-identities/user-identities.ts
@@ -28,10 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import {
-  assertValidRequestParameters,
-  type RequireAtLeastOne,
-} from 'lib/request-parameters.js'
+import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { AcsSystem } from 'lib/resources/acs-system.js'
 import type { AcsUser } from 'lib/resources/acs-user.js'
@@ -187,17 +184,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesAddAcsUserParameters,
     options: UserIdentitiesAddAcsUserOptions = {},
   ): UserIdentitiesAddAcsUserRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/add_acs_user',
-      true,
-      ['acs_user_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/add_acs_user',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_user_id'],
       responseKey: undefined,
       options,
     })
@@ -210,17 +203,13 @@ export class SeamHttpUserIdentities {
     parameters?: UserIdentitiesCreateParameters,
     options: UserIdentitiesCreateOptions = {},
   ): UserIdentitiesCreateRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/create',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'user_identity',
       options,
     })
@@ -233,14 +222,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesDeleteParameters,
     options: UserIdentitiesDeleteOptions = {},
   ): UserIdentitiesDeleteRequest {
-    assertValidRequestParameters(parameters, '/user_identities/delete', true, [
-      'user_identity_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: undefined,
       options,
     })
@@ -253,17 +241,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesGenerateInstantKeyParameters,
     options: UserIdentitiesGenerateInstantKeyOptions = {},
   ): UserIdentitiesGenerateInstantKeyRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/generate_instant_key',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/generate_instant_key',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'instant_key',
       options,
     })
@@ -276,12 +260,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesGetParameters,
     options: UserIdentitiesGetOptions = {},
   ): UserIdentitiesGetRequest {
-    assertValidRequestParameters(parameters, '/user_identities/get', true, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: [],
       responseKey: 'user_identity',
       options,
     })
@@ -294,17 +279,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesGrantAccessToDeviceParameters,
     options: UserIdentitiesGrantAccessToDeviceOptions = {},
   ): UserIdentitiesGrantAccessToDeviceRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/grant_access_to_device',
-      true,
-      ['device_id', 'user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/grant_access_to_device',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'user_identity_id'],
       responseKey: undefined,
       options,
     })
@@ -317,12 +298,13 @@ export class SeamHttpUserIdentities {
     parameters?: UserIdentitiesListParameters,
     options: UserIdentitiesListOptions = {},
   ): UserIdentitiesListRequest {
-    assertValidRequestParameters(parameters, '/user_identities/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/list',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'user_identities',
       options,
     })
@@ -335,17 +317,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesListAccessibleDevicesParameters,
     options: UserIdentitiesListAccessibleDevicesOptions = {},
   ): UserIdentitiesListAccessibleDevicesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/list_accessible_devices',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/list_accessible_devices',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'devices',
       options,
     })
@@ -358,17 +336,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesListAccessibleEntrancesParameters,
     options: UserIdentitiesListAccessibleEntrancesOptions = {},
   ): UserIdentitiesListAccessibleEntrancesRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/list_accessible_entrances',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/list_accessible_entrances',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'acs_entrances',
       options,
     })
@@ -381,17 +355,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesListAcsSystemsParameters,
     options: UserIdentitiesListAcsSystemsOptions = {},
   ): UserIdentitiesListAcsSystemsRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/list_acs_systems',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/list_acs_systems',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'acs_systems',
       options,
     })
@@ -404,17 +374,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesListAcsUsersParameters,
     options: UserIdentitiesListAcsUsersOptions = {},
   ): UserIdentitiesListAcsUsersRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/list_acs_users',
-      true,
-      ['user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/list_acs_users',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: 'acs_users',
       options,
     })
@@ -427,17 +393,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesRemoveAcsUserParameters,
     options: UserIdentitiesRemoveAcsUserOptions = {},
   ): UserIdentitiesRemoveAcsUserRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/remove_acs_user',
-      true,
-      ['acs_user_id', 'user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/remove_acs_user',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['acs_user_id', 'user_identity_id'],
       responseKey: undefined,
       options,
     })
@@ -450,17 +412,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesRevokeAccessToDeviceParameters,
     options: UserIdentitiesRevokeAccessToDeviceOptions = {},
   ): UserIdentitiesRevokeAccessToDeviceRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/user_identities/revoke_access_to_device',
-      true,
-      ['device_id', 'user_identity_id'],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/revoke_access_to_device',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['device_id', 'user_identity_id'],
       responseKey: undefined,
       options,
     })
@@ -473,14 +431,13 @@ export class SeamHttpUserIdentities {
     parameters: UserIdentitiesUpdateParameters,
     options: UserIdentitiesUpdateOptions = {},
   ): UserIdentitiesUpdateRequest {
-    assertValidRequestParameters(parameters, '/user_identities/update', true, [
-      'user_identity_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/user_identities/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['user_identity_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/webhooks/webhooks.ts
+++ b/src/lib/routes/webhooks/webhooks.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { Webhook } from 'lib/resources/webhook.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
 import { SeamHttpRequest } from 'lib/seam-http-request.js'
@@ -166,12 +165,13 @@ export class SeamHttpWebhooks {
     parameters: WebhooksCreateParameters,
     options: WebhooksCreateOptions = {},
   ): WebhooksCreateRequest {
-    assertValidRequestParameters(parameters, '/webhooks/create', true, ['url'])
-
     return new SeamHttpRequest(this, {
       pathname: '/webhooks/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['url'],
       responseKey: 'webhook',
       options,
     })
@@ -184,14 +184,13 @@ export class SeamHttpWebhooks {
     parameters: WebhooksDeleteParameters,
     options: WebhooksDeleteOptions = {},
   ): WebhooksDeleteRequest {
-    assertValidRequestParameters(parameters, '/webhooks/delete', true, [
-      'webhook_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/webhooks/delete',
       method: 'DELETE',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['webhook_id'],
       responseKey: undefined,
       options,
     })
@@ -204,14 +203,13 @@ export class SeamHttpWebhooks {
     parameters: WebhooksGetParameters,
     options: WebhooksGetOptions = {},
   ): WebhooksGetRequest {
-    assertValidRequestParameters(parameters, '/webhooks/get', true, [
-      'webhook_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/webhooks/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['webhook_id'],
       responseKey: 'webhook',
       options,
     })
@@ -224,12 +222,13 @@ export class SeamHttpWebhooks {
     parameters?: WebhooksListParameters,
     options: WebhooksListOptions = {},
   ): WebhooksListRequest {
-    assertValidRequestParameters(parameters, '/webhooks/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/webhooks/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'webhooks',
       options,
     })
@@ -242,15 +241,13 @@ export class SeamHttpWebhooks {
     parameters: WebhooksUpdateParameters,
     options: WebhooksUpdateOptions = {},
   ): WebhooksUpdateRequest {
-    assertValidRequestParameters(parameters, '/webhooks/update', true, [
-      'event_types',
-      'webhook_id',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/webhooks/update',
       method: 'PUT',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['event_types', 'webhook_id'],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/workspaces/workspaces.ts
+++ b/src/lib/routes/workspaces/workspaces.ts
@@ -28,7 +28,6 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import { assertValidRequestParameters } from 'lib/request-parameters.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Workspace } from 'lib/resources/workspace.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
@@ -168,14 +167,13 @@ export class SeamHttpWorkspaces {
     parameters: WorkspacesCreateParameters,
     options: WorkspacesCreateOptions = {},
   ): WorkspacesCreateRequest {
-    assertValidRequestParameters(parameters, '/workspaces/create', true, [
-      'name',
-    ])
-
     return new SeamHttpRequest(this, {
       pathname: '/workspaces/create',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: true,
+      requiredParameterNames: ['name'],
       responseKey: 'workspace',
       options,
     })
@@ -188,12 +186,13 @@ export class SeamHttpWorkspaces {
     parameters?: WorkspacesGetParameters,
     options: WorkspacesGetOptions = {},
   ): WorkspacesGetRequest {
-    assertValidRequestParameters(parameters, '/workspaces/get', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/workspaces/get',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'workspace',
       options,
     })
@@ -206,12 +205,13 @@ export class SeamHttpWorkspaces {
     parameters?: WorkspacesListParameters,
     options: WorkspacesListOptions = {},
   ): WorkspacesListRequest {
-    assertValidRequestParameters(parameters, '/workspaces/list', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/workspaces/list',
       method: 'GET',
       params: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'workspaces',
       options,
     })
@@ -224,17 +224,13 @@ export class SeamHttpWorkspaces {
     parameters?: WorkspacesResetSandboxParameters,
     options: WorkspacesResetSandboxOptions = {},
   ): WorkspacesResetSandboxRequest {
-    assertValidRequestParameters(
-      parameters,
-      '/workspaces/reset_sandbox',
-      false,
-      [],
-    )
-
     return new SeamHttpRequest(this, {
       pathname: '/workspaces/reset_sandbox',
       method: 'POST',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -251,12 +247,13 @@ export class SeamHttpWorkspaces {
     parameters?: WorkspacesUpdateParameters,
     options: WorkspacesUpdateOptions = {},
   ): WorkspacesUpdateRequest {
-    assertValidRequestParameters(parameters, '/workspaces/update', false, [])
-
     return new SeamHttpRequest(this, {
       pathname: '/workspaces/update',
       method: 'PATCH',
       body: parameters,
+      parameters,
+      hasRequiredParameters: false,
+      requiredParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -23,11 +23,6 @@ interface SeamHttpRequestConfig<TResponseKey> {
   readonly responseKey: TResponseKey
   readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
   readonly actionAttempts?: ActionAttemptsClient
-  /**
-   * The parameters as given to the endpoint method, validated when the request
-   * is made. Held separately from `body` and `params` so that `undefined` and
-   * `null` stay distinguishable from an endpoint that takes no parameters.
-   */
   readonly parameters?: unknown
   readonly hasRequiredParameters?: boolean
   readonly requiredParameterNames?: readonly string[]
@@ -131,11 +126,6 @@ export class SeamHttpRequest<
   }
 
   async fetchResponse(): Promise<TResponse> {
-    // Validated here, not when the endpoint method builds this request:
-    // requests are values, and callers may build one well before deciding to
-    // send it. Reporting a bad parameter at build time surprises anyone who
-    // constructs a request up front, e.g. to derive a cache key from it, and
-    // then only sends it once the data it needs is available.
     assertValidRequestParameters(
       this.#config.parameters,
       this.pathname,

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -3,6 +3,7 @@ import type { Method } from 'axios'
 
 import type { Client } from './client.js'
 import type { SeamHttpRequestOptions } from './options.js'
+import { assertValidRequestParameters } from './request-parameters.js'
 import {
   type ActionAttemptsClient,
   resolveActionAttempt,
@@ -22,6 +23,14 @@ interface SeamHttpRequestConfig<TResponseKey> {
   readonly responseKey: TResponseKey
   readonly options?: Pick<SeamHttpRequestOptions, 'waitForActionAttempt'>
   readonly actionAttempts?: ActionAttemptsClient
+  /**
+   * The parameters as given to the endpoint method, validated when the request
+   * is made. Held separately from `body` and `params` so that `undefined` and
+   * `null` stay distinguishable from an endpoint that takes no parameters.
+   */
+  readonly parameters?: unknown
+  readonly hasRequiredParameters?: boolean
+  readonly requiredParameterNames?: readonly string[]
 }
 
 export class SeamHttpRequest<
@@ -122,6 +131,18 @@ export class SeamHttpRequest<
   }
 
   async fetchResponse(): Promise<TResponse> {
+    // Validated here, not when the endpoint method builds this request:
+    // requests are values, and callers may build one well before deciding to
+    // send it. Reporting a bad parameter at build time surprises anyone who
+    // constructs a request up front, e.g. to derive a cache key from it, and
+    // then only sends it once the data it needs is available.
+    assertValidRequestParameters(
+      this.#config.parameters,
+      this.pathname,
+      this.#config.hasRequiredParameters ?? false,
+      this.#config.requiredParameterNames ?? [],
+    )
+
     const { client } = this.#parent
     const response = await client.request({
       url: this.pathname,

--- a/test/seam/connect/request-parameters.test.ts
+++ b/test/seam/connect/request-parameters.test.ts
@@ -4,23 +4,19 @@ import { SeamHttp } from '@seamapi/http/connect'
 
 const seam = SeamHttp.fromApiKey('seam_apikey1_token')
 
-test('endpoint rejects missing required parameters', (t) => {
-  t.throws(
-    () => {
-      // @ts-expect-error Verify requiredness in the generated method signature.
-      seam.devices.get()
-    },
+test('endpoint rejects missing required parameters', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify requiredness in the generated method signature.
+    async () => await seam.devices.get(),
     {
       instanceOf: TypeError,
       message: 'Parameters are required for /devices/get',
     },
   )
 
-  t.throws(
-    () => {
-      // @ts-expect-error Verify an explicitly required schema property makes the argument required.
-      seam.devices.reportProviderMetadata()
-    },
+  await t.throwsAsync(
+    // @ts-expect-error Verify an explicitly required schema property makes the argument required.
+    async () => await seam.devices.reportProviderMetadata(),
     {
       instanceOf: TypeError,
       message: 'Parameters are required for /devices/report_provider_metadata',
@@ -28,12 +24,10 @@ test('endpoint rejects missing required parameters', (t) => {
   )
 })
 
-test('endpoint rejects missing individually required parameters', (t) => {
-  t.throws(
-    () => {
-      // @ts-expect-error Verify required schema properties at runtime.
-      seam.devices.reportProviderMetadata({})
-    },
+test('endpoint rejects missing individually required parameters', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify required schema properties at runtime.
+    async () => await seam.devices.reportProviderMetadata({}),
     {
       instanceOf: TypeError,
       message:
@@ -41,11 +35,12 @@ test('endpoint rejects missing individually required parameters', (t) => {
     },
   )
 
-  t.throws(
-    () => {
-      // @ts-expect-error Verify required schema properties cannot be undefined.
-      seam.devices.reportProviderMetadata({ devices: undefined })
-    },
+  await t.throwsAsync(
+    async () =>
+      await seam.devices.reportProviderMetadata({
+        // @ts-expect-error Verify required schema properties cannot be undefined.
+        devices: undefined,
+      }),
     {
       instanceOf: TypeError,
       message:
@@ -53,11 +48,12 @@ test('endpoint rejects missing individually required parameters', (t) => {
     },
   )
 
-  t.throws(
-    () => {
+  await t.throwsAsync(
+    async () =>
       // @ts-expect-error Verify all missing required parameters are reported.
-      seam.accessCodes.simulate.createUnmanagedAccessCode({ code: '1234' })
-    },
+      await seam.accessCodes.simulate.createUnmanagedAccessCode({
+        code: '1234',
+      }),
     {
       instanceOf: TypeError,
       message:
@@ -66,12 +62,10 @@ test('endpoint rejects missing individually required parameters', (t) => {
   )
 })
 
-test('endpoint rejects an empty required parameters object', (t) => {
-  t.throws(
-    () => {
-      // @ts-expect-error Verify RequireAtLeastOne in the generated parameter type.
-      seam.devices.get({})
-    },
+test('endpoint rejects an empty required parameters object', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify RequireAtLeastOne in the generated parameter type.
+    async () => await seam.devices.get({}),
     {
       instanceOf: TypeError,
       message: 'At least one parameter is required for /devices/get',
@@ -79,12 +73,10 @@ test('endpoint rejects an empty required parameters object', (t) => {
   )
 })
 
-test('endpoint rejects required parameters with only undefined values', (t) => {
-  t.throws(
-    () => {
-      // @ts-expect-error Verify RequireAtLeastOne requires a defined value.
-      seam.devices.get({ device_id: undefined })
-    },
+test('endpoint rejects required parameters with only undefined values', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify RequireAtLeastOne requires a defined value.
+    async () => await seam.devices.get({ device_id: undefined }),
     {
       instanceOf: TypeError,
       message: 'At least one parameter is required for /devices/get',
@@ -92,12 +84,10 @@ test('endpoint rejects required parameters with only undefined values', (t) => {
   )
 })
 
-test('endpoint rejects non-object parameters', (t) => {
-  t.throws(
-    () => {
-      // @ts-expect-error Verify the generated parameter type rejects primitives.
-      seam.devices.list('invalid')
-    },
+test('endpoint rejects non-object parameters', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify the generated parameter type rejects primitives.
+    async () => await seam.devices.list('invalid'),
     {
       instanceOf: TypeError,
       message: 'Parameters for /devices/list must be an object',
@@ -113,4 +103,38 @@ test('endpoint accepts required parameters', (t) => {
   t.notThrows(() => seam.devices.get({ device_id: 'device-id' }))
   t.notThrows(() => seam.devices.get({ name: 'Front Door' }))
   t.notThrows(() => seam.devices.reportProviderMetadata({ devices: [] }))
+})
+
+test('endpoint defers parameter validation until the request is made', (t) => {
+  // A request is a value: callers may build one before deciding to send it, or
+  // to derive a cache key from it, so building must not throw on parameters
+  // that are not ready yet.
+  t.notThrows(() => {
+    // @ts-expect-error Verify an invalid request still builds.
+    seam.devices.get({ device_id: undefined })
+  })
+})
+
+test('deferred validation reports from every request entrypoint', async (t) => {
+  const expected = {
+    instanceOf: TypeError,
+    message: 'At least one parameter is required for /devices/get',
+  }
+
+  // @ts-expect-error Verify an invalid request builds and rejects on use.
+  const build = () => seam.devices.get({ device_id: undefined })
+
+  await t.throwsAsync(async () => await build().execute(), expected)
+  await t.throwsAsync(async () => await build().fetchResponse(), expected)
+  await t.throwsAsync(async () => await build(), expected)
+  await t.throwsAsync(async () => await build().then(), expected)
+})
+
+test('deferred validation leaves request metadata readable', (t) => {
+  // @ts-expect-error Verify an invalid request still exposes its metadata.
+  const request = seam.devices.get({ device_id: undefined })
+
+  t.is(request.pathname, '/devices/get')
+  t.is(request.method, 'GET')
+  t.deepEqual(request.params, { device_id: undefined })
 })

--- a/test/seam/connect/request-parameters.test.ts
+++ b/test/seam/connect/request-parameters.test.ts
@@ -106,9 +106,6 @@ test('endpoint accepts required parameters', (t) => {
 })
 
 test('endpoint defers parameter validation until the request is made', (t) => {
-  // A request is a value: callers may build one before deciding to send it, or
-  // to derive a cache key from it, so building must not throw on parameters
-  // that are not ready yet.
   t.notThrows(() => {
     // @ts-expect-error Verify an invalid request still builds.
     seam.devices.get({ device_id: undefined })


### PR DESCRIPTION
Required-parameter validation ran inside the endpoint method that builds a
request, so it threw synchronously at build time rather than when the request
was sent.

A SeamHttpRequest is a value. Callers may build one well before deciding to
send it — to derive a cache key from it, to hold it while the data it needs
arrives, or to hand it somewhere else entirely. Throwing at build time makes
that surprising: consumers using a data-fetching library commonly construct a
request during render and gate the send on whether the id is known yet, which
means a request that is deliberately not being sent yet takes down the render.

Validation now happens in fetchResponse, so it reports from execute, await,
then, catch and finally — every path that actually talks to the API — and a
request that is never sent never raises. The checks, their order and their
messages are unchanged; only the timing moves. Endpoint methods pass the
parameters and their requiredness to SeamHttpRequest instead of asserting
first, and the parameters are carried separately from body and params so
undefined and null stay distinguishable.

Note this changes an error that previously surfaced synchronously into a
rejected promise. Callers asserting on a synchronous throw need to await
instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VxuhZpWQMkLkdmo9LJC7kY
