### PR TITLE
fix: Reset timeout and formalize retry defaults per attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,14 +465,25 @@ const seam = new SeamHttp({
 ```
 
 Set `timeout` to `0` to disable the timeout entirely.
-A request that times out rejects with an Axios `ETIMEDOUT` error,
-and is retried according to the retry options.
+A request that times out rejects with an Axios `ETIMEDOUT` error.
+Timed-out idempotent requests are retried according to the retry options, with
+the timeout reset for each attempt. Non-idempotent requests are not retried by
+default.
 
 #### Configuring the Axios Client
 
 The Axios client and retry behavior may be configured with custom initiation options
 via [`axiosOptions`][axiosOptions] and [`axiosRetryOptions`][axiosRetryOptions].
 Options are deep merged with the default options.
+
+By default, the SDK makes up to three attempts: the initial request and two
+retries. Retries are limited to `GET`, `HEAD`, `OPTIONS`, `PUT`, and `DELETE`
+requests that fail because of a transport error, timeout, HTTP 429 response, or
+HTTP 5xx response. `POST` and `PATCH` requests are not retried.
+
+Retries use exponential backoff with jitter: approximately 200–240 ms before
+the first retry and 400–480 ms before the second. A longer `Retry-After` header
+is honored. The request timeout is reset for each attempt.
 
 [axiosOptions]: https://axios-http.com/docs/config_defaults
 [axiosRetryOptions]: https://github.com/softonic/axios-retry

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -20,6 +20,18 @@ export interface ClientOptions {
 
 type AxiosRetryConfig = Parameters<AxiosRetry>[1]
 
+type RequiredAxiosRetryConfig = Required<NonNullable<AxiosRetryConfig>>
+
+const defaultAxiosRetryOptions = {
+  retries: 2,
+  retryCondition: isIdempotentRequestError,
+  retryDelay: exponentialDelay,
+  shouldResetTimeout: true,
+  onRetry: () => undefined,
+  onMaxRetryTimesExceeded: () => undefined,
+  validateResponse: null,
+} satisfies RequiredAxiosRetryConfig
+
 export const createClient = (options: ClientOptions): AxiosInstance => {
   const client = axios.create({
     paramsSerializer: serializeUrlSearchParams,
@@ -29,9 +41,7 @@ export const createClient = (options: ClientOptions): AxiosInstance => {
   })
 
   axiosRetry(client, {
-    retries: 2,
-    retryDelay: exponentialDelay,
-    retryCondition: isIdempotentRequestError,
+    ...defaultAxiosRetryOptions,
     ...options.axiosRetryOptions,
   })
 

--- a/test/seam/connect/timeout.test.ts
+++ b/test/seam/connect/timeout.test.ts
@@ -1,3 +1,6 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
 import test from 'ava'
 import { AxiosError } from 'axios'
 import { getTestServer } from 'fixtures/seam/connect/api.js'
@@ -27,6 +30,66 @@ test('SeamHttp: axiosOptions timeout overrides the timeout option', async (t) =>
     axiosOptions: { timeout: 1_000 },
   })
   t.is(seam.client.defaults.timeout, 1_000)
+})
+
+test('SeamHttp: retries timed-out GET requests', async (t) => {
+  let attempts = 0
+  const server = createServer((_request, _response) => {
+    attempts += 1
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  t.teardown(() => {
+    server.closeAllConnections()
+    server.close()
+  })
+
+  const { port } = server.address() as AddressInfo
+  const seam = SeamHttp.fromApiKey('seam_test_api_key', {
+    endpoint: `http://127.0.0.1:${port}`,
+    timeout: 100,
+  })
+
+  const error = await t.throwsAsync(
+    async () => await seam.client.get('/slow'),
+    {
+      instanceOf: AxiosError,
+    },
+  )
+
+  t.is(error?.code, AxiosError.ETIMEDOUT)
+  t.is(attempts, 3)
+})
+
+test('SeamHttp: does not retry timed-out POST requests', async (t) => {
+  let attempts = 0
+  const server = createServer((_request, _response) => {
+    attempts += 1
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  t.teardown(() => {
+    server.closeAllConnections()
+    server.close()
+  })
+
+  const { port } = server.address() as AddressInfo
+  const seam = SeamHttp.fromApiKey('seam_test_api_key', {
+    endpoint: `http://127.0.0.1:${port}`,
+    timeout: 100,
+  })
+
+  const error = await t.throwsAsync(
+    async () => await seam.client.post('/slow'),
+    { instanceOf: AxiosError },
+  )
+
+  t.is(error?.code, AxiosError.ETIMEDOUT)
+  t.is(attempts, 1)
 })
 
 test('SeamHttp: timeout option aborts slow requests', async (t) => {


### PR DESCRIPTION
## Summary

This extracts the retry-logic and README portion of #954 (which also contains an unrelated large `semanticMethod`/`preferredMethod` migration) into a standalone, clean PR off `main`.

Note that `main` already picked up part of #954's retry work via #965 (`retryCondition: isIdempotentRequestError`) and a `fake-seam-connect` bump beyond what #954 had (`^2.0.4` vs `^2.0.3`). This PR adds what's still missing:

- **`src/lib/client.ts`**: formalize the default `axios-retry` config into an explicit `defaultAxiosRetryOptions` object, adding `shouldResetTimeout: true` (so the request timeout is reset on each retry attempt, not just the first), plus explicit `onRetry`, `onMaxRetryTimesExceeded`, and `validateResponse` defaults for a fully-typed `RequiredAxiosRetryConfig`.
- **`test/seam/connect/timeout.test.ts`**: add tests asserting a timed-out `GET` is retried up to 3 total attempts with the timeout reset each time, and a timed-out `POST` is not retried.
- **`README.md`**: document the full default retry policy — 3 total attempts, retries limited to `GET`/`HEAD`/`OPTIONS`/`PUT`/`DELETE` on transport error/timeout/429/5xx, exponential backoff with jitter (~200–240ms then ~400–480ms), `Retry-After` honored, and timeout reset per attempt.

I cross-checked this against the `seamapi/python` and `seamapi/ruby` SDKs, which already document and implement the identical retry policy (same attempt count, method allowlist, trigger conditions, and backoff timing), so this brings the JS SDK's documented/implemented behavior in line with both.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 119 passed (4 pre-existing `test.failing` UPSTREAM markers, unrelated), `client.ts` at 100% coverage, new timeout/retry tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_018WofBNswBgL2VJB1hQi75F)_