### PR TITLE
fix: Send a SeamHttpRequest at most once

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,12 @@ console.log(`${request.method} ${request.url}`, JSON.stringify(request.body))
 const devices = await request.execute()
 ```
 
+A `SeamHttpRequest` is sent at most once.
+Awaiting the same request again,
+or calling `execute`, `then`, `catch`, or `finally` more than once,
+always returns the result of the first execution
+and never repeats the HTTP request.
+
 #### Serializing URL search params
 
 The Seam API parses URL search params as complex types.

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -36,6 +36,11 @@ interface SeamHttpRequestConfig<TResponseKey> {
  * The request is sent once `execute` is called,
  * or when the request is awaited like a Promise,
  * e.g., with `await`, `then`, `catch`, or `finally`.
+ * The request is sent at most once:
+ * awaiting the same SeamHttpRequest again,
+ * or calling `execute`, `then`, `catch`, or `finally` more than once,
+ * always returns the result of the first execution
+ * and never repeats the HTTP request.
  * When the response contains an action attempt,
  * awaiting the request also waits for the action attempt to resolve
  * according to the `waitForActionAttempt` option.
@@ -53,6 +58,12 @@ export class SeamHttpRequest<
 
   readonly #parent: SeamHttpRequestParent
   readonly #config: SeamHttpRequestConfig<TResponseKey>
+
+  #executePromise: Promise<
+    TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
+  > | null = null
+
+  #fetchResponsePromise: Promise<TResponse> | null = null
 
   constructor(
     parent: SeamHttpRequestParent,
@@ -118,8 +129,18 @@ export class SeamHttpRequest<
    * If the response contains an action attempt,
    * waits for the action attempt to resolve
    * according to the `waitForActionAttempt` option.
+   * The request is sent at most once:
+   * calling this method again returns the result of the first call
+   * and never repeats the HTTP request.
    */
   async execute(): Promise<
+    TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
+  > {
+    this.#executePromise ??= this.#execute()
+    return await this.#executePromise
+  }
+
+  async #execute(): Promise<
     TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
   > {
     const response = await this.fetchResponse()
@@ -160,8 +181,16 @@ export class SeamHttpRequest<
   /**
    * Sends the request and returns the entire response body
    * without waiting for any action attempt to resolve.
+   * The request is sent at most once:
+   * calling this method again returns the result of the first call
+   * and never repeats the HTTP request.
    */
   async fetchResponse(): Promise<TResponse> {
+    this.#fetchResponsePromise ??= this.#fetchResponse()
+    return await this.#fetchResponsePromise
+  }
+
+  async #fetchResponse(): Promise<TResponse> {
     assertValidRequestParameters(
       this.#config.parameters,
       this.pathname,

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -172,6 +172,113 @@ test.serial(
   },
 )
 
+test('SeamHttpRequest: sends the request at most once when awaited more than once', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  let requestCount = 0
+  seam.client.interceptors.request.use((config) => {
+    requestCount++
+    return config
+  })
+
+  const request = seam.devices.get({ device_id: seed.august_device_1 })
+
+  const device = await request
+  const deviceAgain = await request
+  const [deviceOnceMore] = await Promise.all([request, request])
+
+  t.is(requestCount, 1)
+  t.is(device.device_id, seed.august_device_1)
+  t.is(deviceAgain.device_id, seed.august_device_1)
+  t.is(deviceOnceMore?.device_id, seed.august_device_1)
+})
+
+test('SeamHttpRequest: catch does not send the request again', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  let requestCount = 0
+  seam.client.interceptors.request.use((config) => {
+    requestCount++
+    return config
+  })
+
+  const request = seam.devices.get({ device_id: seed.august_device_1 })
+
+  const device = await request
+  await request.catch(() => {
+    t.fail('should not reject')
+  })
+
+  t.is(requestCount, 1)
+  t.is(device.device_id, seed.august_device_1)
+})
+
+test('SeamHttpRequest: finally does not send the request again', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  let requestCount = 0
+  seam.client.interceptors.request.use((config) => {
+    requestCount++
+    return config
+  })
+
+  const request = seam.devices.get({ device_id: seed.august_device_1 })
+
+  const device = await request
+  const deviceAgain = await request.finally(() => {})
+
+  t.is(requestCount, 1)
+  t.is(device.device_id, seed.august_device_1)
+  t.is(deviceAgain.device_id, seed.august_device_1)
+})
+
+test('SeamHttpRequest: sends a write request at most once', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint,
+    waitForActionAttempt: false,
+  })
+
+  let writeCount = 0
+  seam.client.interceptors.request.use((config) => {
+    if (config.url === '/locks/unlock_door') writeCount++
+    return config
+  })
+
+  const request = seam.locks.unlockDoor({ device_id: seed.august_device_1 })
+
+  const actionAttempt = await request
+  request.catch(() => {
+    t.fail('should not reject')
+  })
+  const actionAttemptAgain = await request
+
+  t.is(writeCount, 1)
+  t.is(actionAttempt.action_attempt_id, actionAttemptAgain.action_attempt_id)
+})
+
+test('SeamHttpRequest: a rejected request stays rejected when awaited again', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  let requestCount = 0
+  seam.client.interceptors.request.use((config) => {
+    requestCount++
+    return config
+  })
+
+  const request = seam.devices.get({ device_id: 'unknown-device-id' })
+
+  const err = await t.throwsAsync(async () => await request)
+  const errAgain = await t.throwsAsync(async () => await request)
+
+  t.is(requestCount, 1)
+  t.is(err, errAgain)
+})
+
 const toPlainUrlObject = (url: URL): Omit<URL, 'searchParams' | 'toJSON'> => {
   return {
     pathname: url.pathname,


### PR DESCRIPTION
## Problem

SDK audit finding C1 (critical, runtime-verified): a `SeamHttpRequest` re-executes the HTTP request every time it is awaited or given a `then`, `catch`, or `finally` callback — nothing memoizes the in-flight promise. Since the class `implements Promise`, once-only semantics are the reasonable assumption.

```ts
const r = seam.locks.unlockDoor({ device_id }, opts)
r.catch(logError)   // ← this alone issues a second real unlock POST
const aa = await r  // await + await + .catch() = 3 server-observed POSTs
```

Any defensive-logging idiom, `Promise.all([r, r])`, or awaiting a stored request twice duplicates writes: two access codes created, a door unlocked twice. For action-attempt routes each re-execution also restarts a full poll loop.

## Fix

Memoize the promises from `execute()` and `fetchResponse()` in private fields, so the request is sent at most once and every consumer observes the first execution (including a cached rejection). Documented the at-most-once contract in the class JSDoc and the README's *Inspecting the Request* section.

## Tests

New tests count real server hits via a request interceptor against fake-seam-connect:

- double `await` + `Promise.all([r, r])` → 1 request
- `.catch()` after `await` → 1 request
- `.finally()` → 1 request
- write route (`locks.unlockDoor`) awaited twice + `.catch()` → 1 POST, same `action_attempt_id`
- rejected request stays rejected, same error instance, 1 request

Verified per the audit-notes recipe: with the source fix reverted, all 5 new tests fail with the audit's exact symptom (multiple deliveries); with the fix they pass. Full suite: 130 tests, lint, and typecheck green.

Part of applying the rev-3 SDK audit to this SDK (one PR per finding, mirroring seamapi/php#465–#479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_