### PR TITLE
fix: Send the page cursor when the request has no parameters

### DIFF
--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -81,18 +81,21 @@ export class SeamPaginator<
       throw new Error('Cannot paginate a response without a responseKey')
     }
 
+    const method = this.#request.method
+
+    const requestData = {
+      ...(usesParams(method)
+        ? (this.#request.params ?? {})
+        : ((this.#request.body as Record<string, unknown> | null) ?? {})),
+      page_cursor: nextPageCursor,
+    }
+
     const request = new SeamHttpRequest<TResponse, TResponseKey>(this.#parent, {
       pathname: this.#request.pathname,
-      method: this.#request.method,
+      method,
       responseKey,
-      params:
-        this.#request.params != null
-          ? { ...this.#request.params, page_cursor: nextPageCursor }
-          : undefined,
-      body:
-        this.#request.body != null
-          ? { ...this.#request.body, page_cursor: nextPageCursor }
-          : undefined,
+      params: usesParams(method) ? requestData : undefined,
+      body: usesParams(method) ? undefined : requestData,
     })
 
     const response = await request.fetchResponse()
@@ -171,6 +174,9 @@ export class SeamPaginator<
     }
   }
 }
+
+const usesParams = (method: string): boolean =>
+  ['GET', 'DELETE'].includes(method.toUpperCase())
 
 type EnsureReadonlyArray<T> = T extends readonly any[] ? T : never
 type EnsureMutableArray<T> = T extends any[] ? T : never

--- a/test/seam/connect/seam-paginator.test.ts
+++ b/test/seam/connect/seam-paginator.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { getTestServer } from 'fixtures/seam/connect/api.js'
+import nock from 'nock'
 
 import { SeamHttp, SeamPaginator } from '@seamapi/http/connect'
 
@@ -86,6 +87,40 @@ test('SeamPaginator: flatten allows iteration over all devices', async (t) => {
   }
   t.true(devices.length > 1)
   t.is(devices.length, allDevices.length)
+})
+
+test('SeamPaginator: sends the page cursor when the request has no parameters', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  nock(endpoint)
+    .get('/devices/list')
+    .reply(200, {
+      devices: [{ device_id: 'device-1' }],
+      pagination: {
+        has_next_page: true,
+        next_page_cursor: 'page-cursor-1',
+        next_page_url: `${endpoint}/devices/list?page_cursor=page-cursor-1`,
+      },
+    })
+    .get('/devices/list')
+    .query({ page_cursor: 'page-cursor-1', _strict: 'true' })
+    .reply(200, {
+      devices: [{ device_id: 'device-2' }],
+      pagination: {
+        has_next_page: false,
+        next_page_cursor: null,
+        next_page_url: null,
+      },
+    })
+
+  const pages = seam.createPaginator(seam.devices.list())
+  const devices = await pages.flattenToArray()
+
+  t.deepEqual(
+    devices.map(({ device_id: deviceId }) => deviceId),
+    ['device-1', 'device-2'],
+  )
 })
 
 test('SeamPaginator: instance allows iteration over all pages', async (t) => {


### PR DESCRIPTION
## Problem

SDK audit finding C3 (critical, runtime-verified): `SeamPaginator` only attached `page_cursor` to the next-page request when the original request's `params`/`body` was non-null. Every generated list route makes its parameters optional, so `seam.createPaginator(seam.devices.list())` re-sends page 1 forever:

```
runtime: no-args flatten → bodies sent: ["", "", "", ""]      (cursor never attached)
        with-args      → {"limit":1}, {"limit":1,"page_cursor":"c1"}, …  (correct)
```

Against the real API this is an infinite request loop and, via `flattenToArray()`, unbounded memory. Every existing paginator test passed `{ limit: 1 }` — exactly the input that hides the bug.

## Fix

Build the next-page request data unconditionally, choosing `params` vs `body` by the request method (`GET`/`DELETE` → query params, otherwise body) — the same rule codegen uses for the original request.

## Tests

New nock-controlled test: a no-argument `devices.list()` paginator must send `page_cursor` on the page-2 request and terminate. Verified per the audit-notes recipe: with the source fix reverted, the test fails with the audit's exact symptom (page-2 request goes out with no cursor and never matches); with the fix, the full suite (126 tests), lint, and typecheck are green.

Part of applying the rev-3 SDK audit (one PR per finding, mirroring seamapi/php#465–#479). Related: #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_