### PR TITLE
fix: Stop the paginator when a page cursor repeats

### DIFF
--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -130,10 +130,7 @@ export class SeamPaginator<
     EnsureReadonlyArray<TResponse[TResponseKey]>
   > {
     const items = [] as EnsureMutableArray<TResponse[TResponseKey]>
-    let [current, pagination] = await this.firstPage()
-    items.push(...current)
-    while (pagination.hasNextPage) {
-      ;[current, pagination] = await this.nextPage(pagination.nextPageCursor)
+    for await (const [current] of this.#walk()) {
       items.push(...current)
     }
     return items as EnsureReadonlyArray<TResponse[TResponseKey]>
@@ -145,12 +142,7 @@ export class SeamPaginator<
   async *flatten(): AsyncGenerator<
     EnsureReadonlyArray<TResponse[TResponseKey]>
   > {
-    let [current, pagination] = await this.firstPage()
-    for (const item of current) {
-      yield item
-    }
-    while (pagination.hasNextPage) {
-      ;[current, pagination] = await this.nextPage(pagination.nextPageCursor)
+    for await (const [current] of this.#walk()) {
       for (const item of current) {
         yield item
       }
@@ -163,11 +155,29 @@ export class SeamPaginator<
   async *[Symbol.asyncIterator](): AsyncGenerator<
     EnsureReadonlyArray<TResponse[TResponseKey]>
   > {
-    let [current, pagination] = await this.firstPage()
-    yield current
-    while (pagination.hasNextPage) {
-      ;[current, pagination] = await this.nextPage(pagination.nextPageCursor)
+    for await (const [current] of this.#walk()) {
       yield current
+    }
+  }
+
+  /**
+   * Yields each page along with its pagination state.
+   * Iteration stops when there is no next page,
+   * or when the next page cursor is null or repeats a previous cursor,
+   * so a server pinning one cursor cannot cause an infinite request loop.
+   */
+  async *#walk(): AsyncGenerator<
+    [EnsureReadonlyArray<TResponse[TResponseKey]>, Pagination]
+  > {
+    const seenCursors = new Set<SeamPageCursor>()
+    let page = await this.firstPage()
+    yield page
+    while (page[1].hasNextPage) {
+      const cursor = page[1].nextPageCursor
+      if (cursor == null || seenCursors.has(cursor)) return
+      seenCursors.add(cursor)
+      page = await this.nextPage(cursor)
+      yield page
     }
   }
 }

--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -170,12 +170,6 @@ export class SeamPaginator<
     }
   }
 
-  /**
-   * Yields each page along with its pagination state.
-   * Iteration stops when there is no next page,
-   * or when the next page cursor is null or repeats a previous cursor,
-   * so a server pinning one cursor cannot cause an infinite request loop.
-   */
   async *#walk(): AsyncGenerator<
     [EnsureReadonlyArray<TResponse[TResponseKey]>, Pagination]
   > {

--- a/test/seam/connect/seam-paginator.test.ts
+++ b/test/seam/connect/seam-paginator.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { getTestServer } from 'fixtures/seam/connect/api.js'
+import nock from 'nock'
 
 import { SeamHttp, SeamPaginator } from '@seamapi/http/connect'
 
@@ -86,6 +87,68 @@ test('SeamPaginator: flatten allows iteration over all devices', async (t) => {
   }
   t.true(devices.length > 1)
   t.is(devices.length, allDevices.length)
+})
+
+test('SeamPaginator: stops iterating when the page cursor repeats', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  nock(endpoint)
+    .get('/devices/list')
+    .query({ limit: '1', _strict: 'true' })
+    .reply(200, {
+      devices: [{ device_id: 'device-1' }],
+      pagination: {
+        has_next_page: true,
+        next_page_cursor: 'repeated-cursor',
+        next_page_url: null,
+      },
+    })
+    .get('/devices/list')
+    .query({ limit: '1', page_cursor: 'repeated-cursor', _strict: 'true' })
+    .reply(200, {
+      devices: [{ device_id: 'device-2' }],
+      pagination: {
+        has_next_page: true,
+        next_page_cursor: 'repeated-cursor',
+        next_page_url: null,
+      },
+    })
+
+  const pages = seam.createPaginator(seam.devices.list({ limit: 1 }))
+  const devices = await pages.flattenToArray()
+
+  t.deepEqual(
+    devices.map(({ device_id: deviceId }) => deviceId),
+    ['device-1', 'device-2'],
+  )
+})
+
+test('SeamPaginator: stops iterating when there is a next page without a cursor', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  nock(endpoint)
+    .get('/devices/list')
+    .query({ limit: '1', _strict: 'true' })
+    .reply(200, {
+      devices: [{ device_id: 'device-1' }],
+      pagination: {
+        has_next_page: true,
+        next_page_cursor: null,
+        next_page_url: null,
+      },
+    })
+
+  const pages = seam.createPaginator(seam.devices.list({ limit: 1 }))
+
+  const seenPages = []
+  for await (const page of pages) {
+    seenPages.push(page)
+  }
+
+  t.is(seenPages.length, 1)
+  t.is(seenPages[0]?.[0]?.device_id, 'device-1')
 })
 
 test('SeamPaginator: instance allows iteration over all pages', async (t) => {


### PR DESCRIPTION
## Problem

SDK audit finding M6 (medium): the paginator loops on `has_next_page` with no max-pages bound, no cursor-repeat detection. A server regression or proxy-cached page that pins one cursor hangs `flatten()` forever and grows `flattenToArray()` to OOM — the per-request timeout resets every page, so nothing saves the process. A next page reported with a `null` cursor threw a plain error from deep inside iteration.

## Fix

Mirrors seamapi/php#466: `flatten`, `flattenToArray`, and page iteration now delegate to one private `#walk()` generator that tracks seen cursors and stops silently when the next cursor is null or repeats a previous cursor. `firstPage`/`nextPage` are unchanged for manual paging.

## Tests

- server pins one cursor with `has_next_page: true` → iteration terminates after fetching each page once (`['device-1', 'device-2']`)
- `has_next_page: true` with a `null` cursor → iteration ends cleanly after page 1

Per the audit-notes recipe, with the fix reverted the repeat test loops past the mocked pages (fails on the third fetch of the same cursor) and the null-cursor test throws `Cannot get the next page with a null nextPageCursor`. Full suite (127 tests), lint, typecheck green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_