### PR TITLE
fix: Leave pagination params out of the at least one parameter guard

### DIFF
--- a/codegen/layouts/partials/route-class-endpoint-export.hbs
+++ b/codegen/layouts/partials/route-class-endpoint-export.hbs
@@ -1,4 +1,4 @@
-export type {{parametersTypeName}} = {{#if requiresAtLeastOneParameter}}RequireAtLeastOne<{{/if}}{{> request-object parameters=parameters}}{{#if requiresAtLeastOneParameter}}>{{/if}}
+export type {{parametersTypeName}} = {{#if requiresAtLeastOneParameter}}RequireAtLeastOne<{{/if}}{{> request-object parameters=parameters}}{{#if requiresAtLeastOneParameter}}, {{atLeastOneParameterNamesUnion}}>{{/if}}
 
 /**
  * @deprecated Use {{requestTypeName}} instead.

--- a/codegen/layouts/partials/route-class-endpoint.hbs
+++ b/codegen/layouts/partials/route-class-endpoint.hbs
@@ -9,6 +9,7 @@
     parameters,
     hasRequiredParameters: {{hasRequiredParameters}},
     requiredParameterNames: [{{#each requiredParameterNames}}{{json .}}{{#unless @last}}, {{/unless}}{{/each}}],
+    atLeastOneParameterNames: [{{#each atLeastOneParameterNames}}{{json .}}{{#unless @last}}, {{/unless}}{{/each}}],
     responseKey: {{#if returnsVoid}}undefined{{else}}'{{responseKey}}'{{/if}},
     {{#if hasPagination}}hasPagination: true,
     {{/if}}options,

--- a/codegen/lib/layouts/route.ts
+++ b/codegen/lib/layouts/route.ts
@@ -181,8 +181,6 @@ const requiresAtLeastOneParameter = (endpoint: Endpoint): boolean =>
   endpoint.request.hasRequiredParameters &&
   endpoint.request.parameters.every(({ isRequired }) => !isRequired)
 
-// Pagination knobs are not filters: the at least one parameter guard must
-// count filter parameters only, and is dropped when that leaves nothing.
 const paginationParameterNames = new Set(['limit', 'page_cursor'])
 
 const getAtLeastOneParameterNames = (endpoint: Endpoint): string[] =>

--- a/codegen/lib/layouts/route.ts
+++ b/codegen/lib/layouts/route.ts
@@ -40,6 +40,8 @@ export interface EndpointLayoutContext {
   hasRequiredParameters: boolean
   requiredParameterNames: string[]
   requiresAtLeastOneParameter: boolean
+  atLeastOneParameterNames: string[]
+  atLeastOneParameterNamesUnion: string
   parameters: Parameter[]
   responseIsList: boolean
   responseResourceTypeName: string
@@ -72,7 +74,9 @@ export const setRouteLayoutContext = (
   file.needsRequireAtLeastOneImport =
     node != null &&
     'endpoints' in node &&
-    node.endpoints.some(requiresAtLeastOneParameter)
+    node.endpoints.some(
+      (endpoint) => getAtLeastOneParameterNames(endpoint).length > 0,
+    )
   file.resourceTypeImports =
     node != null && 'endpoints' in node
       ? [
@@ -155,7 +159,12 @@ export const getEndpointLayoutContext = (
     requiredParameterNames: endpoint.request.parameters
       .filter(({ isRequired }) => isRequired)
       .map(({ name }) => name),
-    requiresAtLeastOneParameter: requiresAtLeastOneParameter(endpoint),
+    requiresAtLeastOneParameter:
+      getAtLeastOneParameterNames(endpoint).length > 0,
+    atLeastOneParameterNames: getAtLeastOneParameterNames(endpoint),
+    atLeastOneParameterNamesUnion: getAtLeastOneParameterNames(endpoint)
+      .map((name) => `'${name}'`)
+      .join(' | '),
     parameters: endpoint.request.parameters,
     responseIsList: endpoint.response.responseType === 'resource_list',
     responseResourceTypeName:
@@ -171,6 +180,17 @@ export const getEndpointLayoutContext = (
 const requiresAtLeastOneParameter = (endpoint: Endpoint): boolean =>
   endpoint.request.hasRequiredParameters &&
   endpoint.request.parameters.every(({ isRequired }) => !isRequired)
+
+// Pagination knobs are not filters: the at least one parameter guard must
+// count filter parameters only, and is dropped when that leaves nothing.
+const paginationParameterNames = new Set(['limit', 'page_cursor'])
+
+const getAtLeastOneParameterNames = (endpoint: Endpoint): string[] =>
+  requiresAtLeastOneParameter(endpoint)
+    ? endpoint.request.parameters
+        .map(({ name }) => name)
+        .filter((name) => !paginationParameterNames.has(name))
+    : []
 
 const isActionAttemptEndpoint = (endpoint: Endpoint): boolean =>
   endpoint.response.responseType === 'resource' &&

--- a/src/lib/request-parameters.ts
+++ b/src/lib/request-parameters.ts
@@ -10,6 +10,7 @@ export const assertValidRequestParameters = (
   path: string,
   hasRequiredParameters: boolean,
   requiredParameterNames: readonly string[],
+  atLeastOneParameterNames: readonly string[],
 ): void => {
   if (parameters === undefined) {
     if (hasRequiredParameters) {
@@ -37,8 +38,10 @@ export const assertValidRequestParameters = (
   }
 
   if (
-    hasRequiredParameters &&
-    Object.values(parameterValues).every((value) => value === undefined)
+    atLeastOneParameterNames.length > 0 &&
+    atLeastOneParameterNames.every(
+      (name) => parameterValues[name] === undefined,
+    )
   ) {
     throw new TypeError(`At least one parameter is required for ${path}`)
   }

--- a/src/lib/routes/access-codes/access-codes.ts
+++ b/src/lib/routes/access-codes/access-codes.ts
@@ -184,6 +184,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_code',
       options,
     })
@@ -213,6 +214,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_ids'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_codes',
       options,
     })
@@ -232,6 +234,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -251,6 +254,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'generated_code',
       options,
     })
@@ -272,6 +276,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['access_code_id', 'code', 'device_id'],
       responseKey: 'access_code',
       options,
     })
@@ -293,6 +298,16 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_code_ids',
+        'access_grant_id',
+        'access_grant_key',
+        'access_method_id',
+        'customer_key',
+        'device_id',
+        'search',
+        'user_identifier_key',
+      ],
       responseKey: 'access_codes',
       hasPagination: true,
       options,
@@ -321,6 +336,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_code',
       options,
     })
@@ -342,6 +358,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -363,6 +380,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -386,6 +404,7 @@ export class SeamHttpAccessCodes {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['common_code_key'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -587,20 +606,23 @@ export type AccessCodesGenerateCodeRequest = SeamHttpRequest<
 
 export interface AccessCodesGenerateCodeOptions {}
 
-export type AccessCodesGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  access_code_id?: string | undefined
-  /**
-   * Code of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  code?: string | undefined
-  /**
-   * ID of the device containing the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  device_id?: string | undefined
-}>
+export type AccessCodesGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    access_code_id?: string | undefined
+    /**
+     * Code of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    code?: string | undefined
+    /**
+     * ID of the device containing the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    device_id?: string | undefined
+  },
+  'access_code_id' | 'code' | 'device_id'
+>
 
 /**
  * @deprecated Use AccessCodesGetRequest instead.
@@ -614,48 +636,58 @@ export type AccessCodesGetRequest = SeamHttpRequest<
 
 export interface AccessCodesGetOptions {}
 
-export type AccessCodesListParameters = RequireAtLeastOne<{
-  /**
-   * IDs of the access codes that you want to retrieve. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
-   */
-  access_code_ids?: Array<string> | undefined
-  /**
-   * ID of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * Key of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
-   */
-  access_grant_key?: string | undefined
-  /**
-   * ID of the access method for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
-   */
-  access_method_id?: string | undefined
-  /**
-   * Customer key for which you want to list access codes.
-   */
-  customer_key?: string | undefined
-  /**
-   * ID of the device for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
-   */
-  device_id?: string | undefined
-  /**
-   * Numerical limit on the number of access codes to return.
-   */
-  limit?: number | undefined
-  /**
-   * Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
-   */
-  page_cursor?: string | null | undefined
-  /**
-   * String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
-   */
-  search?: string | undefined
-  /**
-   * Your user ID for the user by which to filter access codes.
-   */
-  user_identifier_key?: string | undefined
-}>
+export type AccessCodesListParameters = RequireAtLeastOne<
+  {
+    /**
+     * IDs of the access codes that you want to retrieve. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     */
+    access_code_ids?: Array<string> | undefined
+    /**
+     * ID of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * Key of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     */
+    access_grant_key?: string | undefined
+    /**
+     * ID of the access method for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     */
+    access_method_id?: string | undefined
+    /**
+     * Customer key for which you want to list access codes.
+     */
+    customer_key?: string | undefined
+    /**
+     * ID of the device for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     */
+    device_id?: string | undefined
+    /**
+     * Numerical limit on the number of access codes to return.
+     */
+    limit?: number | undefined
+    /**
+     * Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     */
+    page_cursor?: string | null | undefined
+    /**
+     * String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
+     */
+    search?: string | undefined
+    /**
+     * Your user ID for the user by which to filter access codes.
+     */
+    user_identifier_key?: string | undefined
+  },
+  | 'access_code_ids'
+  | 'access_grant_id'
+  | 'access_grant_key'
+  | 'access_method_id'
+  | 'customer_key'
+  | 'device_id'
+  | 'search'
+  | 'user_identifier_key'
+>
 
 /**
  * @deprecated Use AccessCodesListRequest instead.

--- a/src/lib/routes/access-codes/simulate/simulate.ts
+++ b/src/lib/routes/access-codes/simulate/simulate.ts
@@ -172,6 +172,7 @@ export class SeamHttpAccessCodesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['code', 'device_id', 'name'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_code',
       options,
     })

--- a/src/lib/routes/access-codes/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-codes/unmanaged/unmanaged.ts
@@ -177,6 +177,7 @@ export class SeamHttpAccessCodesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -196,6 +197,7 @@ export class SeamHttpAccessCodesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -217,6 +219,7 @@ export class SeamHttpAccessCodesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['access_code_id', 'code', 'device_id'],
       responseKey: 'access_code',
       options,
     })
@@ -236,6 +239,7 @@ export class SeamHttpAccessCodesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_codes',
       hasPagination: true,
       options,
@@ -256,6 +260,7 @@ export class SeamHttpAccessCodesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_code_id', 'is_managed'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -310,20 +315,23 @@ export type AccessCodesUnmanagedDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface AccessCodesUnmanagedDeleteOptions {}
 
-export type AccessCodesUnmanagedGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  access_code_id?: string | undefined
-  /**
-   * Code of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  code?: string | undefined
-  /**
-   * ID of the device containing the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
-   */
-  device_id?: string | undefined
-}>
+export type AccessCodesUnmanagedGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    access_code_id?: string | undefined
+    /**
+     * Code of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    code?: string | undefined
+    /**
+     * ID of the device containing the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     */
+    device_id?: string | undefined
+  },
+  'access_code_id' | 'code' | 'device_id'
+>
 
 /**
  * @deprecated Use AccessCodesUnmanagedGetRequest instead.

--- a/src/lib/routes/access-grants/access-grants.ts
+++ b/src/lib/routes/access-grants/access-grants.ts
@@ -180,6 +180,7 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['requested_access_methods'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_grant',
       options,
     })
@@ -199,6 +200,7 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_grant_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -218,6 +220,7 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['access_grant_id', 'access_grant_key'],
       responseKey: 'access_grant',
       options,
     })
@@ -237,6 +240,12 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_grant_ids',
+        'access_grant_keys',
+        'exclude',
+        'include',
+      ],
       responseKey: 'batch',
       options,
     })
@@ -256,6 +265,7 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'access_grants',
       hasPagination: true,
       options,
@@ -276,6 +286,7 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_grant_id', 'requested_access_methods'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_grant',
       options,
     })
@@ -295,6 +306,13 @@ export class SeamHttpAccessGrants {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_grant_id',
+        'access_grant_key',
+        'ends_at',
+        'name',
+        'starts_at',
+      ],
       responseKey: undefined,
       options,
     })
@@ -438,16 +456,19 @@ export type AccessGrantsDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface AccessGrantsDeleteOptions {}
 
-export type AccessGrantsGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of Access Grant to get.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * Unique key of Access Grant to get.
-   */
-  access_grant_key?: string | undefined
-}>
+export type AccessGrantsGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of Access Grant to get.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * Unique key of Access Grant to get.
+     */
+    access_grant_key?: string | undefined
+  },
+  'access_grant_id' | 'access_grant_key'
+>
 
 /**
  * @deprecated Use AccessGrantsGetRequest instead.
@@ -461,42 +482,45 @@ export type AccessGrantsGetRequest = SeamHttpRequest<
 
 export interface AccessGrantsGetOptions {}
 
-export type AccessGrantsGetRelatedParameters = RequireAtLeastOne<{
-  /**
-   * IDs of the access grants that you want to get along with their related resources.
-   */
-  access_grant_ids?: Array<string> | undefined
-  /**
-   * Keys of the access grants that you want to get along with their related resources.
-   */
-  access_grant_keys?: Array<string> | undefined
+export type AccessGrantsGetRelatedParameters = RequireAtLeastOne<
+  {
+    /**
+     * IDs of the access grants that you want to get along with their related resources.
+     */
+    access_grant_ids?: Array<string> | undefined
+    /**
+     * Keys of the access grants that you want to get along with their related resources.
+     */
+    access_grant_keys?: Array<string> | undefined
 
-  exclude?:
-    | Array<
-        | 'spaces'
-        | 'devices'
-        | 'acs_entrances'
-        | 'connected_accounts'
-        | 'acs_systems'
-        | 'user_identities'
-        | 'acs_access_groups'
-        | 'access_methods'
-      >
-    | undefined
+    exclude?:
+      | Array<
+          | 'spaces'
+          | 'devices'
+          | 'acs_entrances'
+          | 'connected_accounts'
+          | 'acs_systems'
+          | 'user_identities'
+          | 'acs_access_groups'
+          | 'access_methods'
+        >
+      | undefined
 
-  include?:
-    | Array<
-        | 'spaces'
-        | 'devices'
-        | 'acs_entrances'
-        | 'connected_accounts'
-        | 'acs_systems'
-        | 'user_identities'
-        | 'acs_access_groups'
-        | 'access_methods'
-      >
-    | undefined
-}>
+    include?:
+      | Array<
+          | 'spaces'
+          | 'devices'
+          | 'acs_entrances'
+          | 'connected_accounts'
+          | 'acs_systems'
+          | 'user_identities'
+          | 'acs_access_groups'
+          | 'access_methods'
+        >
+      | undefined
+  },
+  'access_grant_ids' | 'access_grant_keys' | 'exclude' | 'include'
+>
 
 /**
  * @deprecated Use AccessGrantsGetRelatedRequest instead.
@@ -627,28 +651,31 @@ export type AccessGrantsRequestAccessMethodsRequest = SeamHttpRequest<
 
 export interface AccessGrantsRequestAccessMethodsOptions {}
 
-export type AccessGrantsUpdateParameters = RequireAtLeastOne<{
-  /**
-   * ID of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * Key of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
-   */
-  access_grant_key?: string | undefined
-  /**
-   * Date and time at which the validity of the grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
-   */
-  ends_at?: string | Date | Temporal.Instant | null | undefined
-  /**
-   * Display name for the access grant.
-   */
-  name?: string | null | undefined
-  /**
-   * Date and time at which the validity of the grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-   */
-  starts_at?: string | Date | Temporal.Instant | undefined
-}>
+export type AccessGrantsUpdateParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * Key of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+     */
+    access_grant_key?: string | undefined
+    /**
+     * Date and time at which the validity of the grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     */
+    ends_at?: string | Date | Temporal.Instant | null | undefined
+    /**
+     * Display name for the access grant.
+     */
+    name?: string | null | undefined
+    /**
+     * Date and time at which the validity of the grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     */
+    starts_at?: string | Date | Temporal.Instant | undefined
+  },
+  'access_grant_id' | 'access_grant_key' | 'ends_at' | 'name' | 'starts_at'
+>
 
 /**
  * @deprecated Use AccessGrantsUpdateRequest instead.

--- a/src/lib/routes/access-grants/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-grants/unmanaged/unmanaged.ts
@@ -172,6 +172,7 @@ export class SeamHttpAccessGrantsUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_grant_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_grant',
       options,
     })
@@ -191,6 +192,7 @@ export class SeamHttpAccessGrantsUnmanaged {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'access_grants',
       hasPagination: true,
       options,
@@ -215,6 +217,7 @@ export class SeamHttpAccessGrantsUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_grant_id', 'is_managed'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/access-methods/access-methods.ts
+++ b/src/lib/routes/access-methods/access-methods.ts
@@ -182,6 +182,7 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_id', 'card_number'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -205,6 +206,11 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_method_id',
+        'access_grant_id',
+        'reservation_key',
+      ],
       responseKey: undefined,
       options,
     })
@@ -224,6 +230,7 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_id', 'acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -247,6 +254,7 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_method',
       options,
     })
@@ -266,6 +274,7 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_ids'],
+      atLeastOneParameterNames: [],
       responseKey: 'batch',
       options,
     })
@@ -285,6 +294,14 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_code_id',
+        'access_grant_id',
+        'access_grant_key',
+        'acs_entrance_id',
+        'device_id',
+        'space_id',
+      ],
       responseKey: 'access_methods',
       hasPagination: true,
       options,
@@ -305,6 +322,7 @@ export class SeamHttpAccessMethods {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_id', 'acs_entrance_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -342,20 +360,23 @@ export type AccessMethodsAssignCardOptions = Pick<
   'waitForActionAttempt'
 >
 
-export type AccessMethodsDeleteParameters = RequireAtLeastOne<{
-  /**
-   * ID of access method to delete.
-   */
-  access_method_id?: string | undefined
-  /**
-   * ID of access grant whose access methods should be deleted.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * Reservation key of the access grant whose access methods should be deleted.
-   */
-  reservation_key?: string | undefined
-}>
+export type AccessMethodsDeleteParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of access method to delete.
+     */
+    access_method_id?: string | undefined
+    /**
+     * ID of access grant whose access methods should be deleted.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * Reservation key of the access grant whose access methods should be deleted.
+     */
+    reservation_key?: string | undefined
+  },
+  'access_method_id' | 'access_grant_id' | 'reservation_key'
+>
 
 /**
  * @deprecated Use AccessMethodsDeleteRequest instead.
@@ -468,40 +489,48 @@ export type AccessMethodsGetRelatedRequest = SeamHttpRequest<
 
 export interface AccessMethodsGetRelatedOptions {}
 
-export type AccessMethodsListParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access code by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
-   */
-  access_code_id?: string | undefined
-  /**
-   * ID of Access Grant to list access methods for.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * Key of Access Grant to list access methods for.
-   */
-  access_grant_key?: string | undefined
-  /**
-   * ID of the entrance for which you want to retrieve all access methods that grant access to it.
-   */
-  acs_entrance_id?: string | undefined
-  /**
-   * ID of the device by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
-   */
-  device_id?: string | undefined
-  /**
-   * Maximum number of records to return per page.
-   */
-  limit?: number | undefined
-  /**
-   * Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
-   */
-  page_cursor?: string | null | undefined
-  /**
-   * ID of the space by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
-   */
-  space_id?: string | undefined
-}>
+export type AccessMethodsListParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access code by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     */
+    access_code_id?: string | undefined
+    /**
+     * ID of Access Grant to list access methods for.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * Key of Access Grant to list access methods for.
+     */
+    access_grant_key?: string | undefined
+    /**
+     * ID of the entrance for which you want to retrieve all access methods that grant access to it.
+     */
+    acs_entrance_id?: string | undefined
+    /**
+     * ID of the device by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     */
+    device_id?: string | undefined
+    /**
+     * Maximum number of records to return per page.
+     */
+    limit?: number | undefined
+    /**
+     * Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     */
+    page_cursor?: string | null | undefined
+    /**
+     * ID of the space by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     */
+    space_id?: string | undefined
+  },
+  | 'access_code_id'
+  | 'access_grant_id'
+  | 'access_grant_key'
+  | 'acs_entrance_id'
+  | 'device_id'
+  | 'space_id'
+>
 
 /**
  * @deprecated Use AccessMethodsListRequest instead.

--- a/src/lib/routes/access-methods/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-methods/unmanaged/unmanaged.ts
@@ -172,6 +172,7 @@ export class SeamHttpAccessMethodsUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_method',
       options,
     })
@@ -191,6 +192,7 @@ export class SeamHttpAccessMethodsUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_grant_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'access_methods',
       options,
     })

--- a/src/lib/routes/acs/access-groups/access-groups.ts
+++ b/src/lib/routes/acs/access-groups/access-groups.ts
@@ -174,6 +174,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -212,6 +214,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_access_group',
       options,
     })
@@ -231,6 +234,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_access_groups',
       options,
     })
@@ -250,6 +254,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_entrances',
       options,
     })
@@ -269,6 +274,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_users',
       options,
     })
@@ -288,6 +294,7 @@ export class SeamHttpAcsAccessGroups {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/credentials/credentials.ts
+++ b/src/lib/routes/acs/credentials/credentials.ts
@@ -173,6 +173,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -192,6 +193,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['access_method'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_credential',
       options,
     })
@@ -211,6 +213,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -230,6 +233,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_credential',
       options,
     })
@@ -249,6 +253,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_credentials',
       hasPagination: true,
       options,
@@ -269,6 +274,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_entrances',
       options,
     })
@@ -288,6 +294,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -307,6 +314,7 @@ export class SeamHttpAcsCredentials {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/encoders/encoders.ts
+++ b/src/lib/routes/acs/encoders/encoders.ts
@@ -180,6 +180,7 @@ export class SeamHttpAcsEncoders {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -203,6 +204,7 @@ export class SeamHttpAcsEncoders {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_encoder',
       options,
     })
@@ -222,6 +224,7 @@ export class SeamHttpAcsEncoders {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_encoders',
       hasPagination: true,
       options,
@@ -242,6 +245,7 @@ export class SeamHttpAcsEncoders {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -265,6 +269,7 @@ export class SeamHttpAcsEncoders {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/acs/encoders/simulate/simulate.ts
+++ b/src/lib/routes/acs/encoders/simulate/simulate.ts
@@ -171,6 +171,7 @@ export class SeamHttpAcsEncodersSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -190,6 +191,7 @@ export class SeamHttpAcsEncodersSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -209,6 +211,7 @@ export class SeamHttpAcsEncodersSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -228,6 +231,7 @@ export class SeamHttpAcsEncodersSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_encoder_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/entrances/entrances.ts
+++ b/src/lib/routes/acs/entrances/entrances.ts
@@ -175,6 +175,7 @@ export class SeamHttpAcsEntrances {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_entrance_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_entrance',
       options,
     })
@@ -194,6 +195,7 @@ export class SeamHttpAcsEntrances {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_entrance_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -213,6 +215,7 @@ export class SeamHttpAcsEntrances {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_entrances',
       hasPagination: true,
       options,
@@ -233,6 +236,7 @@ export class SeamHttpAcsEntrances {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_entrance_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_credentials',
       options,
     })
@@ -252,6 +256,7 @@ export class SeamHttpAcsEntrances {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_credential_id', 'acs_entrance_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/acs/systems/systems.ts
+++ b/src/lib/routes/acs/systems/systems.ts
@@ -172,6 +172,7 @@ export class SeamHttpAcsSystems {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_system_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_system',
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpAcsSystems {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_systems',
       options,
     })
@@ -214,6 +216,7 @@ export class SeamHttpAcsSystems {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_system_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_systems',
       options,
     })
@@ -233,6 +236,7 @@ export class SeamHttpAcsSystems {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_system_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/acs/users/users.ts
+++ b/src/lib/routes/acs/users/users.ts
@@ -174,6 +174,7 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id', 'acs_user_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_system_id', 'full_name'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_user',
       options,
     })
@@ -212,6 +214,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: undefined,
       options,
     })
@@ -231,6 +238,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: 'acs_user',
       options,
     })
@@ -250,6 +262,7 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_users',
       hasPagination: true,
       options,
@@ -270,6 +283,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: 'acs_entrances',
       options,
     })
@@ -289,6 +307,7 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_access_group_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -308,6 +327,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: undefined,
       options,
     })
@@ -327,6 +351,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: undefined,
       options,
     })
@@ -346,6 +375,11 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'acs_system_id',
+        'acs_user_id',
+        'user_identity_id',
+      ],
       responseKey: undefined,
       options,
     })
@@ -365,6 +399,17 @@ export class SeamHttpAcsUsers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_schedule',
+        'acs_system_id',
+        'acs_user_id',
+        'email',
+        'email_address',
+        'full_name',
+        'hid_acs_system_id',
+        'phone_number',
+        'user_identity_id',
+      ],
       responseKey: undefined,
       options,
     })
@@ -452,20 +497,23 @@ export type AcsUsersCreateRequest = SeamHttpRequest<
 
 export interface AcsUsersCreateOptions {}
 
-export type AcsUsersDeleteParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system that you want to delete. You must provide acs_system_id with user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user that you want to delete. You must provide either acs_user_id or user_identity_id
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity that you want to delete. You must provide either acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersDeleteParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system that you want to delete. You must provide acs_system_id with user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user that you want to delete. You must provide either acs_user_id or user_identity_id
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity that you want to delete. You must provide either acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersDeleteRequest instead.
@@ -476,20 +524,23 @@ export type AcsUsersDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface AcsUsersDeleteOptions {}
 
-export type AcsUsersGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system that you want to get. You can only provide acs_user_id or user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user that you want to get. You can only provide acs_user_id or user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity that you want to get. You can only provide acs_user_id or user_identity_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system that you want to get. You can only provide acs_user_id or user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user that you want to get. You can only provide acs_user_id or user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity that you want to get. You can only provide acs_user_id or user_identity_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersGetRequest instead.
@@ -550,20 +601,23 @@ export type AcsUsersListRequest = SeamHttpRequest<
 
 export interface AcsUsersListOptions {}
 
-export type AcsUsersListAccessibleEntrancesParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system for which you want to list accessible entrances. You can only provide acs_system_id with user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersListAccessibleEntrancesParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system for which you want to list accessible entrances. You can only provide acs_system_id with user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersListAccessibleEntrancesRequest instead.
@@ -607,20 +661,23 @@ export type AcsUsersRemoveFromAccessGroupRequest = SeamHttpRequest<
 
 export interface AcsUsersRemoveFromAccessGroupOptions {}
 
-export type AcsUsersRevokeAccessToAllEntrancesParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system for which you want to revoke access. You can only provide acs_system_id with user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersRevokeAccessToAllEntrancesParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system for which you want to revoke access. You can only provide acs_system_id with user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersRevokeAccessToAllEntrancesRequest instead.
@@ -634,20 +691,23 @@ export type AcsUsersRevokeAccessToAllEntrancesRequest = SeamHttpRequest<
 
 export interface AcsUsersRevokeAccessToAllEntrancesOptions {}
 
-export type AcsUsersSuspendParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersSuspendParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersSuspendRequest instead.
@@ -658,20 +718,23 @@ export type AcsUsersSuspendRequest = SeamHttpRequest<void, undefined>
 
 export interface AcsUsersSuspendOptions {}
 
-export type AcsUsersUnsuspendParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access system of the user that you want to unsuspend. You can only provide acs_system_id with user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * ID of the user identity that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersUnsuspendParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access system of the user that you want to unsuspend. You can only provide acs_system_id with user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * ID of the user identity that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  'acs_system_id' | 'acs_user_id' | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersUnsuspendRequest instead.
@@ -682,56 +745,67 @@ export type AcsUsersUnsuspendRequest = SeamHttpRequest<void, undefined>
 
 export interface AcsUsersUnsuspendOptions {}
 
-export type AcsUsersUpdateParameters = RequireAtLeastOne<{
-  /**
-   * `starts_at` and `ends_at` timestamps for the access system user's access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
-   */
-  access_schedule?:
-    | {
-        /**
-         * Ending timestamp for the access system user's access.
-         */
-        ends_at?: string | Date | Temporal.Instant | undefined
-        /**
-         * Starting timestamp for the access system user's access.
-         */
-        starts_at?: string | Date | Temporal.Instant | undefined
-      }
-    | null
-    | undefined
-  /**
-   * ID of the access system that you want to update. You can only provide acs_system_id with user_identity_id.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * ID of the access system user that you want to update. You can only provide acs_user_id or user_identity_id.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * @deprecated use email_address.
-   */
-  email?: string | undefined
-  /**
-   * Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
-   */
-  email_address?: string | undefined
-  /**
-   * Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
-   */
-  full_name?: string | undefined
-  /**
-   * ID of the HID access control system associated with the user.
-   */
-  hid_acs_system_id?: string | undefined
-  /**
-   * Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
-   */
-  phone_number?: string | undefined
-  /**
-   * ID of the user identity that you want to update. You can only provide acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
-   */
-  user_identity_id?: string | undefined
-}>
+export type AcsUsersUpdateParameters = RequireAtLeastOne<
+  {
+    /**
+     * `starts_at` and `ends_at` timestamps for the access system user's access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
+     */
+    access_schedule?:
+      | {
+          /**
+           * Ending timestamp for the access system user's access.
+           */
+          ends_at?: string | Date | Temporal.Instant | undefined
+          /**
+           * Starting timestamp for the access system user's access.
+           */
+          starts_at?: string | Date | Temporal.Instant | undefined
+        }
+      | null
+      | undefined
+    /**
+     * ID of the access system that you want to update. You can only provide acs_system_id with user_identity_id.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * ID of the access system user that you want to update. You can only provide acs_user_id or user_identity_id.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * @deprecated use email_address.
+     */
+    email?: string | undefined
+    /**
+     * Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     */
+    email_address?: string | undefined
+    /**
+     * Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     */
+    full_name?: string | undefined
+    /**
+     * ID of the HID access control system associated with the user.
+     */
+    hid_acs_system_id?: string | undefined
+    /**
+     * Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+     */
+    phone_number?: string | undefined
+    /**
+     * ID of the user identity that you want to update. You can only provide acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+     */
+    user_identity_id?: string | undefined
+  },
+  | 'access_schedule'
+  | 'acs_system_id'
+  | 'acs_user_id'
+  | 'email'
+  | 'email_address'
+  | 'full_name'
+  | 'hid_acs_system_id'
+  | 'phone_number'
+  | 'user_identity_id'
+>
 
 /**
  * @deprecated Use AcsUsersUpdateRequest instead.

--- a/src/lib/routes/action-attempts/action-attempts.ts
+++ b/src/lib/routes/action-attempts/action-attempts.ts
@@ -172,6 +172,7 @@ export class SeamHttpActionAttempts {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['action_attempt_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -195,6 +196,7 @@ export class SeamHttpActionAttempts {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempts',
       hasPagination: true,
       options,

--- a/src/lib/routes/client-sessions/client-sessions.ts
+++ b/src/lib/routes/client-sessions/client-sessions.ts
@@ -172,6 +172,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -191,6 +192,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['client_session_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -210,6 +212,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -229,6 +232,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'client_session',
       options,
     })
@@ -248,6 +252,14 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'client_session_id',
+        'connect_webview_ids',
+        'connected_account_ids',
+        'user_identifier_key',
+        'user_identity_id',
+        'user_identity_ids',
+      ],
       responseKey: undefined,
       options,
     })
@@ -267,6 +279,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'client_sessions',
       options,
     })
@@ -288,6 +301,7 @@ export class SeamHttpClientSessions {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['client_session_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -423,33 +437,41 @@ export type ClientSessionsGetOrCreateRequest = SeamHttpRequest<
 
 export interface ClientSessionsGetOrCreateOptions {}
 
-export type ClientSessionsGrantAccessParameters = RequireAtLeastOne<{
-  /**
-   * ID of the client session to which you want to grant access to resources.
-   */
-  client_session_id?: string | undefined
-  /**
-   * IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.
-   */
-  connect_webview_ids?: Array<string> | undefined
-  /**
-   * IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.
-   */
-  connected_account_ids?: Array<string> | undefined
-  /**
-   * Your user ID for the user that you want to associate with the client session.
-   */
-  user_identifier_key?: string | undefined
-  /**
-   * ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
-   */
-  user_identity_id?: string | undefined
-  /**
-   * IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
-   * @deprecated Use `user_identity_id`.
-   */
-  user_identity_ids?: Array<string> | undefined
-}>
+export type ClientSessionsGrantAccessParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the client session to which you want to grant access to resources.
+     */
+    client_session_id?: string | undefined
+    /**
+     * IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.
+     */
+    connect_webview_ids?: Array<string> | undefined
+    /**
+     * IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.
+     */
+    connected_account_ids?: Array<string> | undefined
+    /**
+     * Your user ID for the user that you want to associate with the client session.
+     */
+    user_identifier_key?: string | undefined
+    /**
+     * ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     */
+    user_identity_id?: string | undefined
+    /**
+     * IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     * @deprecated Use `user_identity_id`.
+     */
+    user_identity_ids?: Array<string> | undefined
+  },
+  | 'client_session_id'
+  | 'connect_webview_ids'
+  | 'connected_account_ids'
+  | 'user_identifier_key'
+  | 'user_identity_id'
+  | 'user_identity_ids'
+>
 
 /**
  * @deprecated Use ClientSessionsGrantAccessRequest instead.

--- a/src/lib/routes/connect-webviews/connect-webviews.ts
+++ b/src/lib/routes/connect-webviews/connect-webviews.ts
@@ -178,6 +178,7 @@ export class SeamHttpConnectWebviews {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'connect_webview',
       options,
     })
@@ -199,6 +200,7 @@ export class SeamHttpConnectWebviews {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connect_webview_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -220,6 +222,7 @@ export class SeamHttpConnectWebviews {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connect_webview_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'connect_webview',
       options,
     })
@@ -239,6 +242,7 @@ export class SeamHttpConnectWebviews {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'connect_webviews',
       hasPagination: true,
       options,

--- a/src/lib/routes/connected-accounts/connected-accounts.ts
+++ b/src/lib/routes/connected-accounts/connected-accounts.ts
@@ -186,6 +186,7 @@ export class SeamHttpConnectedAccounts {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -205,6 +206,7 @@ export class SeamHttpConnectedAccounts {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['connected_account_id', 'email'],
       responseKey: 'connected_account',
       options,
     })
@@ -224,6 +226,7 @@ export class SeamHttpConnectedAccounts {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'connected_accounts',
       hasPagination: true,
       options,
@@ -244,6 +247,7 @@ export class SeamHttpConnectedAccounts {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -263,6 +267,7 @@ export class SeamHttpConnectedAccounts {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -285,16 +290,19 @@ export type ConnectedAccountsDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface ConnectedAccountsDeleteOptions {}
 
-export type ConnectedAccountsGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the connected account that you want to get.
-   */
-  connected_account_id?: string | undefined
-  /**
-   * Email address associated with the connected account that you want to get.
-   */
-  email?: string | undefined
-}>
+export type ConnectedAccountsGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the connected account that you want to get.
+     */
+    connected_account_id?: string | undefined
+    /**
+     * Email address associated with the connected account that you want to get.
+     */
+    email?: string | undefined
+  },
+  'connected_account_id' | 'email'
+>
 
 /**
  * @deprecated Use ConnectedAccountsGetRequest instead.

--- a/src/lib/routes/connected-accounts/simulate/simulate.ts
+++ b/src/lib/routes/connected-accounts/simulate/simulate.ts
@@ -174,6 +174,7 @@ export class SeamHttpConnectedAccountsSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/customers/customers.ts
+++ b/src/lib/routes/customers/customers.ts
@@ -172,6 +172,7 @@ export class SeamHttpCustomers {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'customer_portal',
       options,
     })
@@ -192,6 +193,7 @@ export class SeamHttpCustomers {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -211,6 +213,7 @@ export class SeamHttpCustomers {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['customer_key'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/devices/devices.ts
+++ b/src/lib/routes/devices/devices.ts
@@ -187,6 +187,7 @@ export class SeamHttpDevices {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['device_id', 'name'],
       responseKey: 'device',
       options,
     })
@@ -206,6 +207,7 @@ export class SeamHttpDevices {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       hasPagination: true,
       options,
@@ -230,6 +232,7 @@ export class SeamHttpDevices {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'device_providers',
       options,
     })
@@ -249,6 +252,7 @@ export class SeamHttpDevices {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['devices'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -270,22 +274,26 @@ export class SeamHttpDevices {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
   }
 }
 
-export type DevicesGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the device that you want to get.
-   */
-  device_id?: string | undefined
-  /**
-   * Name of the device that you want to get.
-   */
-  name?: string | undefined
-}>
+export type DevicesGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the device that you want to get.
+     */
+    device_id?: string | undefined
+    /**
+     * Name of the device that you want to get.
+     */
+    name?: string | undefined
+  },
+  'device_id' | 'name'
+>
 
 /**
  * @deprecated Use DevicesGetRequest instead.

--- a/src/lib/routes/devices/simulate/simulate.ts
+++ b/src/lib/routes/devices/simulate/simulate.ts
@@ -171,6 +171,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -212,6 +214,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -235,6 +238,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -256,6 +260,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'is_expired'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -275,6 +280,7 @@ export class SeamHttpDevicesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/devices/unmanaged/unmanaged.ts
+++ b/src/lib/routes/devices/unmanaged/unmanaged.ts
@@ -177,6 +177,7 @@ export class SeamHttpDevicesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['device_id', 'name'],
       responseKey: 'device',
       options,
     })
@@ -198,6 +199,7 @@ export class SeamHttpDevicesUnmanaged {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       hasPagination: true,
       options,
@@ -220,22 +222,26 @@ export class SeamHttpDevicesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
   }
 }
 
-export type DevicesUnmanagedGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the unmanaged device that you want to get.
-   */
-  device_id?: string | undefined
-  /**
-   * Name of the unmanaged device that you want to get.
-   */
-  name?: string | undefined
-}>
+export type DevicesUnmanagedGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the unmanaged device that you want to get.
+     */
+    device_id?: string | undefined
+    /**
+     * Name of the unmanaged device that you want to get.
+     */
+    name?: string | undefined
+  },
+  'device_id' | 'name'
+>
 
 /**
  * @deprecated Use DevicesUnmanagedGetRequest instead.

--- a/src/lib/routes/events/events.ts
+++ b/src/lib/routes/events/events.ts
@@ -173,6 +173,7 @@ export class SeamHttpEvents {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['device_id', 'event_id', 'event_type'],
       responseKey: 'event',
       options,
     })
@@ -192,26 +193,58 @@ export class SeamHttpEvents {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'access_code_id',
+        'access_code_ids',
+        'access_grant_id',
+        'access_grant_ids',
+        'access_method_id',
+        'access_method_ids',
+        'acs_access_group_id',
+        'acs_credential_id',
+        'acs_encoder_id',
+        'acs_entrance_id',
+        'acs_system_id',
+        'acs_system_ids',
+        'acs_user_id',
+        'between',
+        'connect_webview_id',
+        'connected_account_id',
+        'customer_key',
+        'device_id',
+        'device_ids',
+        'event_ids',
+        'event_type',
+        'event_types',
+        'since',
+        'space_id',
+        'space_ids',
+        'unstable_offset',
+        'user_identity_id',
+      ],
       responseKey: 'events',
       options,
     })
   }
 }
 
-export type EventsGetParameters = RequireAtLeastOne<{
-  /**
-   * Unique identifier for the device that triggered the event that you want to get.
-   */
-  device_id?: string | undefined
-  /**
-   * Unique identifier for the event that you want to get.
-   */
-  event_id?: string | undefined
-  /**
-   * Type of the event that you want to get.
-   */
-  event_type?: string | undefined
-}>
+export type EventsGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * Unique identifier for the device that triggered the event that you want to get.
+     */
+    device_id?: string | undefined
+    /**
+     * Unique identifier for the event that you want to get.
+     */
+    event_id?: string | undefined
+    /**
+     * Type of the event that you want to get.
+     */
+    event_type?: string | undefined
+  },
+  'device_id' | 'event_id' | 'event_type'
+>
 
 /**
  * @deprecated Use EventsGetRequest instead.
@@ -222,352 +255,381 @@ export type EventsGetRequest = SeamHttpRequest<EventsGetResponse, 'event'>
 
 export interface EventsGetOptions {}
 
-export type EventsListParameters = RequireAtLeastOne<{
-  /**
-   * ID of the access code for which you want to list events.
-   */
-  access_code_id?: string | undefined
-  /**
-   * IDs of the access codes for which you want to list events.
-   */
-  access_code_ids?: Array<string> | undefined
-  /**
-   * ID of the access grant for which you want to list events.
-   */
-  access_grant_id?: string | undefined
-  /**
-   * IDs of the access grants for which you want to list events.
-   */
-  access_grant_ids?: Array<string> | undefined
-  /**
-   * ID of the access method for which you want to list events.
-   */
-  access_method_id?: string | undefined
-  /**
-   * IDs of the access methods for which you want to list events.
-   */
-  access_method_ids?: Array<string> | undefined
-  /**
-   * ID of the ACS access group for which you want to list events.
-   */
-  acs_access_group_id?: string | undefined
-  /**
-   * ID of the ACS credential for which you want to list events.
-   */
-  acs_credential_id?: string | undefined
-  /**
-   * ID of the ACS encoder for which you want to list events.
-   */
-  acs_encoder_id?: string | undefined
-  /**
-   * ID of the ACS entrance for which you want to list events.
-   */
-  acs_entrance_id?: string | undefined
-  /**
-   * ID of the access system for which you want to list events.
-   */
-  acs_system_id?: string | undefined
-  /**
-   * IDs of the access systems for which you want to list events.
-   */
-  acs_system_ids?: Array<string> | undefined
-  /**
-   * ID of the ACS user for which you want to list events.
-   */
-  acs_user_id?: string | undefined
-  /**
-   * Lower and upper timestamps to define an exclusive interval containing the events that you want to list. You must include `since` or `between`.
-   */
-  between?: Array<string> | undefined
-  /**
-   * ID of the Connect Webview for which you want to list events.
-   */
-  connect_webview_id?: string | undefined
-  /**
-   * ID of the connected account for which you want to list events.
-   */
-  connected_account_id?: string | undefined
-  /**
-   * Customer key for which you want to list events.
-   */
-  customer_key?: string | undefined
-  /**
-   * ID of the device for which you want to list events.
-   */
-  device_id?: string | undefined
-  /**
-   * IDs of the devices for which you want to list events.
-   */
-  device_ids?: Array<string> | undefined
-  /**
-   * IDs of the events that you want to list.
-   */
-  event_ids?: Array<string> | undefined
-  /**
-   * Type of the events that you want to list.
-   */
-  event_type?:
-    | 'access_code.created'
-    | 'access_code.changed'
-    | 'access_code.name_changed'
-    | 'access_code.code_changed'
-    | 'access_code.time_frame_changed'
-    | 'access_code.mutations_requested'
-    | 'access_code.scheduled_on_device'
-    | 'access_code.set_on_device'
-    | 'access_code.removed_from_device'
-    | 'access_code.delay_in_setting_on_device'
-    | 'access_code.failed_to_set_on_device'
-    | 'access_code.issued'
-    | 'access_code.delay_in_issuing'
-    | 'access_code.failed_to_issue'
-    | 'access_code.failed_to_update'
-    | 'access_code.failed_to_expire'
-    | 'access_code.deleted'
-    | 'access_code.delay_in_removing_from_device'
-    | 'access_code.failed_to_remove_from_device'
-    | 'access_code.modified_external_to_seam'
-    | 'access_code.deleted_external_to_seam'
-    | 'access_code.backup_access_code_pulled'
-    | 'access_code.unmanaged.converted_to_managed'
-    | 'access_code.unmanaged.failed_to_convert_to_managed'
-    | 'access_code.unmanaged.created'
-    | 'access_code.unmanaged.removed'
-    | 'access_grant.created'
-    | 'access_grant.deleted'
-    | 'access_grant.access_granted_to_all_doors'
-    | 'access_grant.access_granted_to_door'
-    | 'access_grant.access_to_door_lost'
-    | 'access_grant.access_times_changed'
-    | 'access_grant.could_not_create_requested_access_methods'
-    | 'access_method.issued'
-    | 'access_method.revoked'
-    | 'access_method.card_encoding_required'
-    | 'access_method.deleted'
-    | 'access_method.reissued'
-    | 'access_method.created'
-    | 'access_method.delay_in_issuing'
-    | 'access_method.failed_to_issue'
-    | 'acs_system.connected'
-    | 'acs_system.added'
-    | 'acs_system.disconnected'
-    | 'acs_credential.deleted'
-    | 'acs_credential.issued'
-    | 'acs_credential.reissued'
-    | 'acs_credential.invalidated'
-    | 'acs_user.created'
-    | 'acs_user.deleted'
-    | 'acs_encoder.added'
-    | 'acs_encoder.removed'
-    | 'acs_access_group.deleted'
-    | 'acs_entrance.added'
-    | 'acs_entrance.removed'
-    | 'client_session.deleted'
-    | 'connected_account.connected'
-    | 'connected_account.created'
-    | 'connected_account.successful_login'
-    | 'connected_account.disconnected'
-    | 'connected_account.completed_first_sync'
-    | 'connected_account.deleted'
-    | 'connected_account.completed_first_sync_after_reconnection'
-    | 'connected_account.reauthorization_requested'
-    | 'action_attempt.lock_door.succeeded'
-    | 'action_attempt.lock_door.failed'
-    | 'action_attempt.unlock_door.succeeded'
-    | 'action_attempt.unlock_door.failed'
-    | 'action_attempt.simulate_keypad_code_entry.succeeded'
-    | 'action_attempt.simulate_keypad_code_entry.failed'
-    | 'action_attempt.simulate_manual_lock_via_keypad.succeeded'
-    | 'action_attempt.simulate_manual_lock_via_keypad.failed'
-    | 'connect_webview.login_succeeded'
-    | 'connect_webview.login_failed'
-    | 'device.connected'
-    | 'device.added'
-    | 'device.converted_to_unmanaged'
-    | 'device.unmanaged.converted_to_managed'
-    | 'device.unmanaged.connected'
-    | 'device.disconnected'
-    | 'device.unmanaged.disconnected'
-    | 'device.tampered'
-    | 'device.low_battery'
-    | 'device.battery_status_changed'
-    | 'device.removed'
-    | 'device.deleted'
-    | 'device.third_party_integration_detected'
-    | 'device.third_party_integration_no_longer_detected'
-    | 'device.salto.privacy_mode_activated'
-    | 'device.salto.privacy_mode_deactivated'
-    | 'device.connection_became_flaky'
-    | 'device.connection_stabilized'
-    | 'device.error.subscription_required'
-    | 'device.error.subscription_required.resolved'
-    | 'device.accessory_keypad_connected'
-    | 'device.accessory_keypad_disconnected'
-    | 'noise_sensor.noise_threshold_triggered'
-    | 'lock.locked'
-    | 'lock.unlocked'
-    | 'lock.access_denied'
-    | 'thermostat.climate_preset_activated'
-    | 'thermostat.manually_adjusted'
-    | 'thermostat.temperature_threshold_exceeded'
-    | 'thermostat.temperature_threshold_no_longer_exceeded'
-    | 'thermostat.temperature_reached_set_point'
-    | 'thermostat.temperature_changed'
-    | 'device.name_changed'
-    | 'camera.activated'
-    | 'device.doorbell_rang'
-    | 'enrollment_automation.deleted'
-    | 'phone.deactivated'
-    | 'space.device_membership_changed'
-    | 'space.created'
-    | 'space.deleted'
-    | undefined
-  /**
-   * Types of the events that you want to list.
-   */
-  event_types?:
-    | Array<
-        | 'access_code.created'
-        | 'access_code.changed'
-        | 'access_code.name_changed'
-        | 'access_code.code_changed'
-        | 'access_code.time_frame_changed'
-        | 'access_code.mutations_requested'
-        | 'access_code.scheduled_on_device'
-        | 'access_code.set_on_device'
-        | 'access_code.removed_from_device'
-        | 'access_code.delay_in_setting_on_device'
-        | 'access_code.failed_to_set_on_device'
-        | 'access_code.issued'
-        | 'access_code.delay_in_issuing'
-        | 'access_code.failed_to_issue'
-        | 'access_code.failed_to_update'
-        | 'access_code.failed_to_expire'
-        | 'access_code.deleted'
-        | 'access_code.delay_in_removing_from_device'
-        | 'access_code.failed_to_remove_from_device'
-        | 'access_code.modified_external_to_seam'
-        | 'access_code.deleted_external_to_seam'
-        | 'access_code.backup_access_code_pulled'
-        | 'access_code.unmanaged.converted_to_managed'
-        | 'access_code.unmanaged.failed_to_convert_to_managed'
-        | 'access_code.unmanaged.created'
-        | 'access_code.unmanaged.removed'
-        | 'access_grant.created'
-        | 'access_grant.deleted'
-        | 'access_grant.access_granted_to_all_doors'
-        | 'access_grant.access_granted_to_door'
-        | 'access_grant.access_to_door_lost'
-        | 'access_grant.access_times_changed'
-        | 'access_grant.could_not_create_requested_access_methods'
-        | 'access_method.issued'
-        | 'access_method.revoked'
-        | 'access_method.card_encoding_required'
-        | 'access_method.deleted'
-        | 'access_method.reissued'
-        | 'access_method.created'
-        | 'access_method.delay_in_issuing'
-        | 'access_method.failed_to_issue'
-        | 'acs_system.connected'
-        | 'acs_system.added'
-        | 'acs_system.disconnected'
-        | 'acs_credential.deleted'
-        | 'acs_credential.issued'
-        | 'acs_credential.reissued'
-        | 'acs_credential.invalidated'
-        | 'acs_user.created'
-        | 'acs_user.deleted'
-        | 'acs_encoder.added'
-        | 'acs_encoder.removed'
-        | 'acs_access_group.deleted'
-        | 'acs_entrance.added'
-        | 'acs_entrance.removed'
-        | 'client_session.deleted'
-        | 'connected_account.connected'
-        | 'connected_account.created'
-        | 'connected_account.successful_login'
-        | 'connected_account.disconnected'
-        | 'connected_account.completed_first_sync'
-        | 'connected_account.deleted'
-        | 'connected_account.completed_first_sync_after_reconnection'
-        | 'connected_account.reauthorization_requested'
-        | 'action_attempt.lock_door.succeeded'
-        | 'action_attempt.lock_door.failed'
-        | 'action_attempt.unlock_door.succeeded'
-        | 'action_attempt.unlock_door.failed'
-        | 'action_attempt.simulate_keypad_code_entry.succeeded'
-        | 'action_attempt.simulate_keypad_code_entry.failed'
-        | 'action_attempt.simulate_manual_lock_via_keypad.succeeded'
-        | 'action_attempt.simulate_manual_lock_via_keypad.failed'
-        | 'connect_webview.login_succeeded'
-        | 'connect_webview.login_failed'
-        | 'device.connected'
-        | 'device.added'
-        | 'device.converted_to_unmanaged'
-        | 'device.unmanaged.converted_to_managed'
-        | 'device.unmanaged.connected'
-        | 'device.disconnected'
-        | 'device.unmanaged.disconnected'
-        | 'device.tampered'
-        | 'device.low_battery'
-        | 'device.battery_status_changed'
-        | 'device.removed'
-        | 'device.deleted'
-        | 'device.third_party_integration_detected'
-        | 'device.third_party_integration_no_longer_detected'
-        | 'device.salto.privacy_mode_activated'
-        | 'device.salto.privacy_mode_deactivated'
-        | 'device.connection_became_flaky'
-        | 'device.connection_stabilized'
-        | 'device.error.subscription_required'
-        | 'device.error.subscription_required.resolved'
-        | 'device.accessory_keypad_connected'
-        | 'device.accessory_keypad_disconnected'
-        | 'noise_sensor.noise_threshold_triggered'
-        | 'lock.locked'
-        | 'lock.unlocked'
-        | 'lock.access_denied'
-        | 'thermostat.climate_preset_activated'
-        | 'thermostat.manually_adjusted'
-        | 'thermostat.temperature_threshold_exceeded'
-        | 'thermostat.temperature_threshold_no_longer_exceeded'
-        | 'thermostat.temperature_reached_set_point'
-        | 'thermostat.temperature_changed'
-        | 'device.name_changed'
-        | 'camera.activated'
-        | 'device.doorbell_rang'
-        | 'enrollment_automation.deleted'
-        | 'phone.deactivated'
-        | 'space.device_membership_changed'
-        | 'space.created'
-        | 'space.deleted'
-      >
-    | undefined
-  /**
-   * Numerical limit on the number of events to return.
-   */
-  limit?: number | undefined
-  /**
-   * Timestamp to indicate the beginning generation time for the events that you want to list. You must include `since` or `between`.
-   */
-  since?: string | undefined
-  /**
-   * ID of the space for which you want to list events.
-   */
-  space_id?: string | undefined
-  /**
-   * IDs of the spaces for which you want to list events.
-   */
-  space_ids?: Array<string> | undefined
-  /**
-   * Offset for the events that you want to list.
-   */
-  unstable_offset?: number | undefined
-  /**
-   * ID of the user identity for which you want to list events.
-   */
-  user_identity_id?: string | undefined
-}>
+export type EventsListParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the access code for which you want to list events.
+     */
+    access_code_id?: string | undefined
+    /**
+     * IDs of the access codes for which you want to list events.
+     */
+    access_code_ids?: Array<string> | undefined
+    /**
+     * ID of the access grant for which you want to list events.
+     */
+    access_grant_id?: string | undefined
+    /**
+     * IDs of the access grants for which you want to list events.
+     */
+    access_grant_ids?: Array<string> | undefined
+    /**
+     * ID of the access method for which you want to list events.
+     */
+    access_method_id?: string | undefined
+    /**
+     * IDs of the access methods for which you want to list events.
+     */
+    access_method_ids?: Array<string> | undefined
+    /**
+     * ID of the ACS access group for which you want to list events.
+     */
+    acs_access_group_id?: string | undefined
+    /**
+     * ID of the ACS credential for which you want to list events.
+     */
+    acs_credential_id?: string | undefined
+    /**
+     * ID of the ACS encoder for which you want to list events.
+     */
+    acs_encoder_id?: string | undefined
+    /**
+     * ID of the ACS entrance for which you want to list events.
+     */
+    acs_entrance_id?: string | undefined
+    /**
+     * ID of the access system for which you want to list events.
+     */
+    acs_system_id?: string | undefined
+    /**
+     * IDs of the access systems for which you want to list events.
+     */
+    acs_system_ids?: Array<string> | undefined
+    /**
+     * ID of the ACS user for which you want to list events.
+     */
+    acs_user_id?: string | undefined
+    /**
+     * Lower and upper timestamps to define an exclusive interval containing the events that you want to list. You must include `since` or `between`.
+     */
+    between?: Array<string> | undefined
+    /**
+     * ID of the Connect Webview for which you want to list events.
+     */
+    connect_webview_id?: string | undefined
+    /**
+     * ID of the connected account for which you want to list events.
+     */
+    connected_account_id?: string | undefined
+    /**
+     * Customer key for which you want to list events.
+     */
+    customer_key?: string | undefined
+    /**
+     * ID of the device for which you want to list events.
+     */
+    device_id?: string | undefined
+    /**
+     * IDs of the devices for which you want to list events.
+     */
+    device_ids?: Array<string> | undefined
+    /**
+     * IDs of the events that you want to list.
+     */
+    event_ids?: Array<string> | undefined
+    /**
+     * Type of the events that you want to list.
+     */
+    event_type?:
+      | 'access_code.created'
+      | 'access_code.changed'
+      | 'access_code.name_changed'
+      | 'access_code.code_changed'
+      | 'access_code.time_frame_changed'
+      | 'access_code.mutations_requested'
+      | 'access_code.scheduled_on_device'
+      | 'access_code.set_on_device'
+      | 'access_code.removed_from_device'
+      | 'access_code.delay_in_setting_on_device'
+      | 'access_code.failed_to_set_on_device'
+      | 'access_code.issued'
+      | 'access_code.delay_in_issuing'
+      | 'access_code.failed_to_issue'
+      | 'access_code.failed_to_update'
+      | 'access_code.failed_to_expire'
+      | 'access_code.deleted'
+      | 'access_code.delay_in_removing_from_device'
+      | 'access_code.failed_to_remove_from_device'
+      | 'access_code.modified_external_to_seam'
+      | 'access_code.deleted_external_to_seam'
+      | 'access_code.backup_access_code_pulled'
+      | 'access_code.unmanaged.converted_to_managed'
+      | 'access_code.unmanaged.failed_to_convert_to_managed'
+      | 'access_code.unmanaged.created'
+      | 'access_code.unmanaged.removed'
+      | 'access_grant.created'
+      | 'access_grant.deleted'
+      | 'access_grant.access_granted_to_all_doors'
+      | 'access_grant.access_granted_to_door'
+      | 'access_grant.access_to_door_lost'
+      | 'access_grant.access_times_changed'
+      | 'access_grant.could_not_create_requested_access_methods'
+      | 'access_method.issued'
+      | 'access_method.revoked'
+      | 'access_method.card_encoding_required'
+      | 'access_method.deleted'
+      | 'access_method.reissued'
+      | 'access_method.created'
+      | 'access_method.delay_in_issuing'
+      | 'access_method.failed_to_issue'
+      | 'acs_system.connected'
+      | 'acs_system.added'
+      | 'acs_system.disconnected'
+      | 'acs_credential.deleted'
+      | 'acs_credential.issued'
+      | 'acs_credential.reissued'
+      | 'acs_credential.invalidated'
+      | 'acs_user.created'
+      | 'acs_user.deleted'
+      | 'acs_encoder.added'
+      | 'acs_encoder.removed'
+      | 'acs_access_group.deleted'
+      | 'acs_entrance.added'
+      | 'acs_entrance.removed'
+      | 'client_session.deleted'
+      | 'connected_account.connected'
+      | 'connected_account.created'
+      | 'connected_account.successful_login'
+      | 'connected_account.disconnected'
+      | 'connected_account.completed_first_sync'
+      | 'connected_account.deleted'
+      | 'connected_account.completed_first_sync_after_reconnection'
+      | 'connected_account.reauthorization_requested'
+      | 'action_attempt.lock_door.succeeded'
+      | 'action_attempt.lock_door.failed'
+      | 'action_attempt.unlock_door.succeeded'
+      | 'action_attempt.unlock_door.failed'
+      | 'action_attempt.simulate_keypad_code_entry.succeeded'
+      | 'action_attempt.simulate_keypad_code_entry.failed'
+      | 'action_attempt.simulate_manual_lock_via_keypad.succeeded'
+      | 'action_attempt.simulate_manual_lock_via_keypad.failed'
+      | 'connect_webview.login_succeeded'
+      | 'connect_webview.login_failed'
+      | 'device.connected'
+      | 'device.added'
+      | 'device.converted_to_unmanaged'
+      | 'device.unmanaged.converted_to_managed'
+      | 'device.unmanaged.connected'
+      | 'device.disconnected'
+      | 'device.unmanaged.disconnected'
+      | 'device.tampered'
+      | 'device.low_battery'
+      | 'device.battery_status_changed'
+      | 'device.removed'
+      | 'device.deleted'
+      | 'device.third_party_integration_detected'
+      | 'device.third_party_integration_no_longer_detected'
+      | 'device.salto.privacy_mode_activated'
+      | 'device.salto.privacy_mode_deactivated'
+      | 'device.connection_became_flaky'
+      | 'device.connection_stabilized'
+      | 'device.error.subscription_required'
+      | 'device.error.subscription_required.resolved'
+      | 'device.accessory_keypad_connected'
+      | 'device.accessory_keypad_disconnected'
+      | 'noise_sensor.noise_threshold_triggered'
+      | 'lock.locked'
+      | 'lock.unlocked'
+      | 'lock.access_denied'
+      | 'thermostat.climate_preset_activated'
+      | 'thermostat.manually_adjusted'
+      | 'thermostat.temperature_threshold_exceeded'
+      | 'thermostat.temperature_threshold_no_longer_exceeded'
+      | 'thermostat.temperature_reached_set_point'
+      | 'thermostat.temperature_changed'
+      | 'device.name_changed'
+      | 'camera.activated'
+      | 'device.doorbell_rang'
+      | 'enrollment_automation.deleted'
+      | 'phone.deactivated'
+      | 'space.device_membership_changed'
+      | 'space.created'
+      | 'space.deleted'
+      | undefined
+    /**
+     * Types of the events that you want to list.
+     */
+    event_types?:
+      | Array<
+          | 'access_code.created'
+          | 'access_code.changed'
+          | 'access_code.name_changed'
+          | 'access_code.code_changed'
+          | 'access_code.time_frame_changed'
+          | 'access_code.mutations_requested'
+          | 'access_code.scheduled_on_device'
+          | 'access_code.set_on_device'
+          | 'access_code.removed_from_device'
+          | 'access_code.delay_in_setting_on_device'
+          | 'access_code.failed_to_set_on_device'
+          | 'access_code.issued'
+          | 'access_code.delay_in_issuing'
+          | 'access_code.failed_to_issue'
+          | 'access_code.failed_to_update'
+          | 'access_code.failed_to_expire'
+          | 'access_code.deleted'
+          | 'access_code.delay_in_removing_from_device'
+          | 'access_code.failed_to_remove_from_device'
+          | 'access_code.modified_external_to_seam'
+          | 'access_code.deleted_external_to_seam'
+          | 'access_code.backup_access_code_pulled'
+          | 'access_code.unmanaged.converted_to_managed'
+          | 'access_code.unmanaged.failed_to_convert_to_managed'
+          | 'access_code.unmanaged.created'
+          | 'access_code.unmanaged.removed'
+          | 'access_grant.created'
+          | 'access_grant.deleted'
+          | 'access_grant.access_granted_to_all_doors'
+          | 'access_grant.access_granted_to_door'
+          | 'access_grant.access_to_door_lost'
+          | 'access_grant.access_times_changed'
+          | 'access_grant.could_not_create_requested_access_methods'
+          | 'access_method.issued'
+          | 'access_method.revoked'
+          | 'access_method.card_encoding_required'
+          | 'access_method.deleted'
+          | 'access_method.reissued'
+          | 'access_method.created'
+          | 'access_method.delay_in_issuing'
+          | 'access_method.failed_to_issue'
+          | 'acs_system.connected'
+          | 'acs_system.added'
+          | 'acs_system.disconnected'
+          | 'acs_credential.deleted'
+          | 'acs_credential.issued'
+          | 'acs_credential.reissued'
+          | 'acs_credential.invalidated'
+          | 'acs_user.created'
+          | 'acs_user.deleted'
+          | 'acs_encoder.added'
+          | 'acs_encoder.removed'
+          | 'acs_access_group.deleted'
+          | 'acs_entrance.added'
+          | 'acs_entrance.removed'
+          | 'client_session.deleted'
+          | 'connected_account.connected'
+          | 'connected_account.created'
+          | 'connected_account.successful_login'
+          | 'connected_account.disconnected'
+          | 'connected_account.completed_first_sync'
+          | 'connected_account.deleted'
+          | 'connected_account.completed_first_sync_after_reconnection'
+          | 'connected_account.reauthorization_requested'
+          | 'action_attempt.lock_door.succeeded'
+          | 'action_attempt.lock_door.failed'
+          | 'action_attempt.unlock_door.succeeded'
+          | 'action_attempt.unlock_door.failed'
+          | 'action_attempt.simulate_keypad_code_entry.succeeded'
+          | 'action_attempt.simulate_keypad_code_entry.failed'
+          | 'action_attempt.simulate_manual_lock_via_keypad.succeeded'
+          | 'action_attempt.simulate_manual_lock_via_keypad.failed'
+          | 'connect_webview.login_succeeded'
+          | 'connect_webview.login_failed'
+          | 'device.connected'
+          | 'device.added'
+          | 'device.converted_to_unmanaged'
+          | 'device.unmanaged.converted_to_managed'
+          | 'device.unmanaged.connected'
+          | 'device.disconnected'
+          | 'device.unmanaged.disconnected'
+          | 'device.tampered'
+          | 'device.low_battery'
+          | 'device.battery_status_changed'
+          | 'device.removed'
+          | 'device.deleted'
+          | 'device.third_party_integration_detected'
+          | 'device.third_party_integration_no_longer_detected'
+          | 'device.salto.privacy_mode_activated'
+          | 'device.salto.privacy_mode_deactivated'
+          | 'device.connection_became_flaky'
+          | 'device.connection_stabilized'
+          | 'device.error.subscription_required'
+          | 'device.error.subscription_required.resolved'
+          | 'device.accessory_keypad_connected'
+          | 'device.accessory_keypad_disconnected'
+          | 'noise_sensor.noise_threshold_triggered'
+          | 'lock.locked'
+          | 'lock.unlocked'
+          | 'lock.access_denied'
+          | 'thermostat.climate_preset_activated'
+          | 'thermostat.manually_adjusted'
+          | 'thermostat.temperature_threshold_exceeded'
+          | 'thermostat.temperature_threshold_no_longer_exceeded'
+          | 'thermostat.temperature_reached_set_point'
+          | 'thermostat.temperature_changed'
+          | 'device.name_changed'
+          | 'camera.activated'
+          | 'device.doorbell_rang'
+          | 'enrollment_automation.deleted'
+          | 'phone.deactivated'
+          | 'space.device_membership_changed'
+          | 'space.created'
+          | 'space.deleted'
+        >
+      | undefined
+    /**
+     * Numerical limit on the number of events to return.
+     */
+    limit?: number | undefined
+    /**
+     * Timestamp to indicate the beginning generation time for the events that you want to list. You must include `since` or `between`.
+     */
+    since?: string | undefined
+    /**
+     * ID of the space for which you want to list events.
+     */
+    space_id?: string | undefined
+    /**
+     * IDs of the spaces for which you want to list events.
+     */
+    space_ids?: Array<string> | undefined
+    /**
+     * Offset for the events that you want to list.
+     */
+    unstable_offset?: number | undefined
+    /**
+     * ID of the user identity for which you want to list events.
+     */
+    user_identity_id?: string | undefined
+  },
+  | 'access_code_id'
+  | 'access_code_ids'
+  | 'access_grant_id'
+  | 'access_grant_ids'
+  | 'access_method_id'
+  | 'access_method_ids'
+  | 'acs_access_group_id'
+  | 'acs_credential_id'
+  | 'acs_encoder_id'
+  | 'acs_entrance_id'
+  | 'acs_system_id'
+  | 'acs_system_ids'
+  | 'acs_user_id'
+  | 'between'
+  | 'connect_webview_id'
+  | 'connected_account_id'
+  | 'customer_key'
+  | 'device_id'
+  | 'device_ids'
+  | 'event_ids'
+  | 'event_type'
+  | 'event_types'
+  | 'since'
+  | 'space_id'
+  | 'space_ids'
+  | 'unstable_offset'
+  | 'user_identity_id'
+>
 
 /**
  * @deprecated Use EventsListRequest instead.

--- a/src/lib/routes/instant-keys/instant-keys.ts
+++ b/src/lib/routes/instant-keys/instant-keys.ts
@@ -173,6 +173,7 @@ export class SeamHttpInstantKeys {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['instant_key_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -192,6 +193,7 @@ export class SeamHttpInstantKeys {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['instant_key_id', 'instant_key_url'],
       responseKey: 'instant_key',
       options,
     })
@@ -211,6 +213,7 @@ export class SeamHttpInstantKeys {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'instant_keys',
       options,
     })
@@ -233,16 +236,19 @@ export type InstantKeysDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface InstantKeysDeleteOptions {}
 
-export type InstantKeysGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the instant key to get.
-   */
-  instant_key_id?: string | undefined
-  /**
-   * URL of the instant key to get.
-   */
-  instant_key_url?: string | undefined
-}>
+export type InstantKeysGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the instant key to get.
+     */
+    instant_key_id?: string | undefined
+    /**
+     * URL of the instant key to get.
+     */
+    instant_key_url?: string | undefined
+  },
+  'instant_key_id' | 'instant_key_url'
+>
 
 /**
  * @deprecated Use InstantKeysGetRequest instead.

--- a/src/lib/routes/locks/locks.ts
+++ b/src/lib/routes/locks/locks.ts
@@ -181,6 +181,7 @@ export class SeamHttpLocks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['auto_lock_enabled', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -205,6 +206,7 @@ export class SeamHttpLocks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['device_id', 'name'],
       responseKey: 'device',
       options,
     })
@@ -224,6 +226,7 @@ export class SeamHttpLocks {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -243,6 +246,7 @@ export class SeamHttpLocks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -266,6 +270,7 @@ export class SeamHttpLocks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -307,16 +312,19 @@ export type LocksConfigureAutoLockOptions = Pick<
   'waitForActionAttempt'
 >
 
-export type LocksGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the lock that you want to get.
-   */
-  device_id?: string | undefined
-  /**
-   * Name of the lock that you want to get.
-   */
-  name?: string | undefined
-}>
+export type LocksGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the lock that you want to get.
+     */
+    device_id?: string | undefined
+    /**
+     * Name of the lock that you want to get.
+     */
+    name?: string | undefined
+  },
+  'device_id' | 'name'
+>
 
 /**
  * @deprecated Use LocksGetRequest instead.

--- a/src/lib/routes/locks/simulate/simulate.ts
+++ b/src/lib/routes/locks/simulate/simulate.ts
@@ -173,6 +173,7 @@ export class SeamHttpLocksSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['code', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -196,6 +197,7 @@ export class SeamHttpLocksSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/noise-sensors/noise-sensors.ts
+++ b/src/lib/routes/noise-sensors/noise-sensors.ts
@@ -186,6 +186,7 @@ export class SeamHttpNoiseSensors {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       options,
     })

--- a/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
+++ b/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
@@ -175,6 +175,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'ends_daily_at', 'starts_daily_at'],
+      atLeastOneParameterNames: [],
       responseKey: 'noise_threshold',
       options,
     })
@@ -194,6 +195,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'noise_threshold_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -213,6 +215,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['noise_threshold_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'noise_threshold',
       options,
     })
@@ -232,6 +235,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'noise_thresholds',
       options,
     })
@@ -251,6 +255,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'noise_threshold_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/noise-sensors/simulate/simulate.ts
+++ b/src/lib/routes/noise-sensors/simulate/simulate.ts
@@ -171,6 +171,7 @@ export class SeamHttpNoiseSensorsSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/phones/phones.ts
+++ b/src/lib/routes/phones/phones.ts
@@ -178,6 +178,7 @@ export class SeamHttpPhones {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -197,6 +198,7 @@ export class SeamHttpPhones {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'phone',
       options,
     })
@@ -216,6 +218,7 @@ export class SeamHttpPhones {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'phones',
       options,
     })

--- a/src/lib/routes/phones/simulate/simulate.ts
+++ b/src/lib/routes/phones/simulate/simulate.ts
@@ -172,6 +172,7 @@ export class SeamHttpPhonesSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'phone',
       options,
     })

--- a/src/lib/routes/spaces/spaces.ts
+++ b/src/lib/routes/spaces/spaces.ts
@@ -174,6 +174,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_entrance_ids', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -212,6 +214,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_ids', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -231,6 +234,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['name'],
+      atLeastOneParameterNames: [],
       responseKey: 'space',
       options,
     })
@@ -250,6 +254,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -269,6 +274,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['space_id', 'space_key'],
       responseKey: 'space',
       options,
     })
@@ -288,6 +294,12 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'exclude',
+        'include',
+        'space_ids',
+        'space_keys',
+      ],
       responseKey: 'batch',
       options,
     })
@@ -307,6 +319,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'spaces',
       hasPagination: true,
       options,
@@ -327,6 +340,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_entrance_ids', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -346,6 +360,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['connected_account_id', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -365,6 +380,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_ids', 'space_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -384,6 +400,7 @@ export class SeamHttpSpaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'space',
       options,
     })
@@ -529,16 +546,19 @@ export type SpacesDeleteRequest = SeamHttpRequest<void, undefined>
 
 export interface SpacesDeleteOptions {}
 
-export type SpacesGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the space that you want to get.
-   */
-  space_id?: string | undefined
-  /**
-   * Unique key of the space that you want to get.
-   */
-  space_key?: string | undefined
-}>
+export type SpacesGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the space that you want to get.
+     */
+    space_id?: string | undefined
+    /**
+     * Unique key of the space that you want to get.
+     */
+    space_key?: string | undefined
+  },
+  'space_id' | 'space_key'
+>
 
 /**
  * @deprecated Use SpacesGetRequest instead.
@@ -549,37 +569,40 @@ export type SpacesGetRequest = SeamHttpRequest<SpacesGetResponse, 'space'>
 
 export interface SpacesGetOptions {}
 
-export type SpacesGetRelatedParameters = RequireAtLeastOne<{
-  exclude?:
-    | Array<
-        | 'spaces'
-        | 'devices'
-        | 'acs_entrances'
-        | 'connected_accounts'
-        | 'acs_systems'
-        | 'access_methods'
-      >
-    | undefined
+export type SpacesGetRelatedParameters = RequireAtLeastOne<
+  {
+    exclude?:
+      | Array<
+          | 'spaces'
+          | 'devices'
+          | 'acs_entrances'
+          | 'connected_accounts'
+          | 'acs_systems'
+          | 'access_methods'
+        >
+      | undefined
 
-  include?:
-    | Array<
-        | 'spaces'
-        | 'devices'
-        | 'acs_entrances'
-        | 'connected_accounts'
-        | 'acs_systems'
-        | 'access_methods'
-      >
-    | undefined
-  /**
-   * IDs of the spaces that you want to get along with their related resources.
-   */
-  space_ids?: Array<string> | undefined
-  /**
-   * Keys of the spaces that you want to get along with their related resources.
-   */
-  space_keys?: Array<string> | undefined
-}>
+    include?:
+      | Array<
+          | 'spaces'
+          | 'devices'
+          | 'acs_entrances'
+          | 'connected_accounts'
+          | 'acs_systems'
+          | 'access_methods'
+        >
+      | undefined
+    /**
+     * IDs of the spaces that you want to get along with their related resources.
+     */
+    space_ids?: Array<string> | undefined
+    /**
+     * Keys of the spaces that you want to get along with their related resources.
+     */
+    space_keys?: Array<string> | undefined
+  },
+  'exclude' | 'include' | 'space_ids' | 'space_keys'
+>
 
 /**
  * @deprecated Use SpacesGetRelatedRequest instead.

--- a/src/lib/routes/thermostats/daily-programs/daily-programs.ts
+++ b/src/lib/routes/thermostats/daily-programs/daily-programs.ts
@@ -177,6 +177,7 @@ export class SeamHttpThermostatsDailyPrograms {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'name', 'periods'],
+      atLeastOneParameterNames: [],
       responseKey: 'thermostat_daily_program',
       options,
     })
@@ -196,6 +197,7 @@ export class SeamHttpThermostatsDailyPrograms {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['thermostat_daily_program_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -219,6 +221,7 @@ export class SeamHttpThermostatsDailyPrograms {
         'periods',
         'thermostat_daily_program_id',
       ],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/thermostats/schedules/schedules.ts
+++ b/src/lib/routes/thermostats/schedules/schedules.ts
@@ -177,6 +177,7 @@ export class SeamHttpThermostatsSchedules {
         'ends_at',
         'starts_at',
       ],
+      atLeastOneParameterNames: [],
       responseKey: 'thermostat_schedule',
       options,
     })
@@ -196,6 +197,7 @@ export class SeamHttpThermostatsSchedules {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['thermostat_schedule_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -215,6 +217,7 @@ export class SeamHttpThermostatsSchedules {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['thermostat_schedule_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'thermostat_schedule',
       options,
     })
@@ -234,6 +237,7 @@ export class SeamHttpThermostatsSchedules {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'thermostat_schedules',
       options,
     })
@@ -253,6 +257,7 @@ export class SeamHttpThermostatsSchedules {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['thermostat_schedule_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/thermostats/simulate/simulate.ts
+++ b/src/lib/routes/thermostats/simulate/simulate.ts
@@ -171,6 +171,7 @@ export class SeamHttpThermostatsSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'hvac_mode'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -190,6 +191,7 @@ export class SeamHttpThermostatsSimulate {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/thermostats/thermostats.ts
+++ b/src/lib/routes/thermostats/thermostats.ts
@@ -193,6 +193,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['climate_preset_key', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -216,6 +217,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -239,6 +241,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['climate_preset_key', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -258,6 +261,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['climate_preset_key', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -277,6 +281,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -300,6 +305,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -323,6 +329,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -342,6 +349,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -365,6 +373,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['climate_preset_key', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -384,6 +393,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -407,6 +417,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'hvac_mode_setting'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -430,6 +441,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -449,6 +461,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['climate_preset_key', 'device_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -468,6 +481,7 @@ export class SeamHttpThermostats {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {

--- a/src/lib/routes/user-identities/unmanaged/unmanaged.ts
+++ b/src/lib/routes/user-identities/unmanaged/unmanaged.ts
@@ -175,6 +175,7 @@ export class SeamHttpUserIdentitiesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'user_identity',
       options,
     })
@@ -194,6 +195,7 @@ export class SeamHttpUserIdentitiesUnmanaged {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'user_identities',
       hasPagination: true,
       options,
@@ -216,6 +218,7 @@ export class SeamHttpUserIdentitiesUnmanaged {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['is_managed', 'user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/user-identities/user-identities.ts
+++ b/src/lib/routes/user-identities/user-identities.ts
@@ -191,6 +191,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_user_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -210,6 +211,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'user_identity',
       options,
     })
@@ -229,6 +231,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -248,6 +251,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'instant_key',
       options,
     })
@@ -267,6 +271,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: ['user_identity_id', 'user_identity_key'],
       responseKey: 'user_identity',
       options,
     })
@@ -286,6 +291,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -305,6 +311,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'user_identities',
       hasPagination: true,
       options,
@@ -325,6 +332,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'devices',
       options,
     })
@@ -344,6 +352,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_entrances',
       options,
     })
@@ -363,6 +372,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_systems',
       options,
     })
@@ -382,6 +392,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'acs_users',
       options,
     })
@@ -407,6 +418,12 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [
+        'merged_user_identity_ids',
+        'user_identity_id',
+        'merged_user_identity_keys',
+        'user_identity_key',
+      ],
       responseKey: undefined,
       options,
     })
@@ -426,6 +443,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['acs_user_id', 'user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -445,6 +463,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['device_id', 'user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -464,6 +483,7 @@ export class SeamHttpUserIdentities {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['user_identity_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -572,14 +592,17 @@ export type UserIdentitiesGenerateInstantKeyRequest = SeamHttpRequest<
 
 export interface UserIdentitiesGenerateInstantKeyOptions {}
 
-export type UserIdentitiesGetParameters = RequireAtLeastOne<{
-  /**
-   * ID of the user identity that you want to get.
-   */
-  user_identity_id?: string | undefined
+export type UserIdentitiesGetParameters = RequireAtLeastOne<
+  {
+    /**
+     * ID of the user identity that you want to get.
+     */
+    user_identity_id?: string | undefined
 
-  user_identity_key?: string | undefined
-}>
+    user_identity_key?: string | undefined
+  },
+  'user_identity_id' | 'user_identity_key'
+>
 
 /**
  * @deprecated Use UserIdentitiesGetRequest instead.
@@ -740,24 +763,30 @@ export type UserIdentitiesListAcsUsersRequest = SeamHttpRequest<
 
 export interface UserIdentitiesListAcsUsersOptions {}
 
-export type UserIdentitiesMergeParameters = RequireAtLeastOne<{
-  /**
-   * IDs of the user identities to merge into the primary user identity. These user identities are deleted.
-   */
-  merged_user_identity_ids?: Array<string> | undefined
-  /**
-   * ID of the primary user identity to keep.
-   */
-  user_identity_id?: string | undefined
-  /**
-   * Keys of the user identities to merge into the primary user identity. These user identities are deleted.
-   */
-  merged_user_identity_keys?: Array<string> | undefined
-  /**
-   * Key of the primary user identity to keep.
-   */
-  user_identity_key?: string | undefined
-}>
+export type UserIdentitiesMergeParameters = RequireAtLeastOne<
+  {
+    /**
+     * IDs of the user identities to merge into the primary user identity. These user identities are deleted.
+     */
+    merged_user_identity_ids?: Array<string> | undefined
+    /**
+     * ID of the primary user identity to keep.
+     */
+    user_identity_id?: string | undefined
+    /**
+     * Keys of the user identities to merge into the primary user identity. These user identities are deleted.
+     */
+    merged_user_identity_keys?: Array<string> | undefined
+    /**
+     * Key of the primary user identity to keep.
+     */
+    user_identity_key?: string | undefined
+  },
+  | 'merged_user_identity_ids'
+  | 'user_identity_id'
+  | 'merged_user_identity_keys'
+  | 'user_identity_key'
+>
 
 /**
  * @deprecated Use UserIdentitiesMergeRequest instead.

--- a/src/lib/routes/webhooks/webhooks.ts
+++ b/src/lib/routes/webhooks/webhooks.ts
@@ -172,6 +172,7 @@ export class SeamHttpWebhooks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['url'],
+      atLeastOneParameterNames: [],
       responseKey: 'webhook',
       options,
     })
@@ -191,6 +192,7 @@ export class SeamHttpWebhooks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['webhook_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })
@@ -210,6 +212,7 @@ export class SeamHttpWebhooks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['webhook_id'],
+      atLeastOneParameterNames: [],
       responseKey: 'webhook',
       options,
     })
@@ -229,6 +232,7 @@ export class SeamHttpWebhooks {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'webhooks',
       options,
     })
@@ -248,6 +252,7 @@ export class SeamHttpWebhooks {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['event_types', 'webhook_id'],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/routes/workspaces/workspaces.ts
+++ b/src/lib/routes/workspaces/workspaces.ts
@@ -174,6 +174,7 @@ export class SeamHttpWorkspaces {
       parameters,
       hasRequiredParameters: true,
       requiredParameterNames: ['name'],
+      atLeastOneParameterNames: [],
       responseKey: 'workspace',
       options,
     })
@@ -193,6 +194,7 @@ export class SeamHttpWorkspaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'workspace',
       options,
     })
@@ -212,6 +214,7 @@ export class SeamHttpWorkspaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'workspaces',
       options,
     })
@@ -231,6 +234,7 @@ export class SeamHttpWorkspaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: 'action_attempt',
       options,
       actionAttempts: SeamHttpActionAttempts.fromClient(this.client, {
@@ -254,6 +258,7 @@ export class SeamHttpWorkspaces {
       parameters,
       hasRequiredParameters: false,
       requiredParameterNames: [],
+      atLeastOneParameterNames: [],
       responseKey: undefined,
       options,
     })

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -27,6 +27,7 @@ interface SeamHttpRequestConfig<TResponseKey> {
   readonly parameters?: unknown
   readonly hasRequiredParameters?: boolean
   readonly requiredParameterNames?: readonly string[]
+  readonly atLeastOneParameterNames?: readonly string[]
 }
 
 /**
@@ -167,6 +168,7 @@ export class SeamHttpRequest<
       this.pathname,
       this.#config.hasRequiredParameters ?? false,
       this.#config.requiredParameterNames ?? [],
+      this.#config.atLeastOneParameterNames ?? [],
     )
 
     const { client } = this.#parent

--- a/test/seam/connect/request-parameters.test.ts
+++ b/test/seam/connect/request-parameters.test.ts
@@ -93,6 +93,33 @@ test('endpoint rejects required parameters with only undefined values', async (t
   )
 })
 
+test('endpoint rejects required parameters satisfied only by pagination parameters', async (t) => {
+  await t.throwsAsync(
+    // @ts-expect-error Verify pagination parameters do not satisfy RequireAtLeastOne.
+    async () => await seam.accessCodes.list({ limit: 10 }),
+    {
+      instanceOf: TypeError,
+      message: 'At least one parameter is required for /access_codes/list',
+    },
+  )
+
+  await t.throwsAsync(
+    async () =>
+      // @ts-expect-error Verify a page cursor does not satisfy RequireAtLeastOne.
+      await seam.accessCodes.list({ limit: 10, page_cursor: 'some-cursor' }),
+    {
+      instanceOf: TypeError,
+      message: 'At least one parameter is required for /access_codes/list',
+    },
+  )
+})
+
+test('endpoint accepts a filter parameter along with pagination parameters', (t) => {
+  t.notThrows(() =>
+    seam.accessCodes.list({ device_id: 'device-id', limit: 10 }),
+  )
+})
+
 test('endpoint rejects non-object parameters', async (t) => {
   await t.throwsAsync(
     // @ts-expect-error Verify the generated parameter type rejects primitives.


### PR DESCRIPTION
## Problem

SDK audit finding M7 (medium): the "at least one parameter" runtime guard scanned every value in the params object, and the generated `RequireAtLeastOne` type spanned every parameter. So `seam.accessCodes.list({ limit: 10 })` — naming no filter at all — satisfied both the type and the runtime guard (false assurance), and a paginated request satisfied the guard from page 2 onward purely because `page_cursor` was set. Pagination knobs are not filters.

## Fix

Mirrors seamapi/php#474, applied at the codegen level:

- `codegen/lib/layouts/route.ts` computes `atLeastOneParameterNames` — the endpoint's parameter names minus `limit`/`page_cursor` — and drops the guard entirely if that leaves nothing.
- Generated request configs carry the list, and `assertValidRequestParameters` checks exactly those names instead of scanning every value.
- Generated parameter types are now `RequireAtLeastOne<{...}, 'device_id' | 'name' | …>` over the same names, so the type level and runtime agree — `{ limit: 10 }` alone no longer typechecks either.

Regenerated with `npm ci && npm run generate`; the diff is the two guard fields across route files (28 `RequireAtLeastOne` wrappers regenerated with keys, none dropped — no endpoint has only pagination params today).

## Tests

- `accessCodes.list({ limit: 10 })` and `accessCodes.list({ limit, page_cursor })` → `At least one parameter is required for /access_codes/list` (on reverted source this request sails past the guard onto the network — the audit's exact symptom)
- `accessCodes.list({ device_id, limit })` builds fine
- existing guard tests unchanged and green

Full suite (127 tests), lint, typecheck green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_