### PR TITLE
fix: Type flatten as yielding items instead of pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ const pages = seam.createPaginator(
 )
 
 for await (const device of pages.flatten()) {
-  console.log(devices.name)
+  console.log(device.display_name)
 }
 ```
 

--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -142,9 +142,7 @@ export class SeamPaginator<
   /**
    * Yields each item across all pages, fetching the next page as needed.
    */
-  async *flatten(): AsyncGenerator<
-    EnsureReadonlyArray<TResponse[TResponseKey]>
-  > {
+  async *flatten(): AsyncGenerator<ElementOfArray<TResponse[TResponseKey]>> {
     let [current, pagination] = await this.firstPage()
     for (const item of current) {
       yield item
@@ -174,6 +172,8 @@ export class SeamPaginator<
 
 type EnsureReadonlyArray<T> = T extends readonly any[] ? T : never
 type EnsureMutableArray<T> = T extends any[] ? T : never
+type ElementOfArray<T> =
+  T extends ReadonlyArray<infer TElement> ? TElement : never
 
 interface PaginationData {
   has_next_page: boolean

--- a/test/seam/connect/seam-paginator.test.ts
+++ b/test/seam/connect/seam-paginator.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { getTestServer } from 'fixtures/seam/connect/api.js'
 
-import { SeamHttp, SeamPaginator } from '@seamapi/http/connect'
+import { type Device, SeamHttp, SeamPaginator } from '@seamapi/http/connect'
 
 test('SeamPaginator: creates a SeamPaginator', async (t) => {
   const { seed, endpoint } = await getTestServer(t)
@@ -80,13 +80,20 @@ test('SeamPaginator: flatten allows iteration over all devices', async (t) => {
   const allDevices = await seam.devices.list()
   const pages = seam.createPaginator(seam.devices.list({ limit: 1 }))
 
-  const devices = []
+  const deviceIds = []
   for await (const device of pages.flatten()) {
-    devices.push(device)
+    expectType<Device>(device)
+
+    // @ts-expect-error Verify flatten yields single items, not pages.
+    expectType<Device[]>(device)
+
+    deviceIds.push(device.device_id)
   }
-  t.true(devices.length > 1)
-  t.is(devices.length, allDevices.length)
+  t.true(deviceIds.length > 1)
+  t.is(deviceIds.length, allDevices.length)
 })
+
+const expectType = <Expected>(_value: Expected): void => {}
 
 test('SeamPaginator: instance allows iteration over all pages', async (t) => {
   const { seed, endpoint } = await getTestServer(t)


### PR DESCRIPTION
## Problem

SDK audit finding M11d (medium, type-only): `SeamPaginator.flatten()` declared its yield type as the page array while the generator yields single items, so `for await (const device of pages.flatten())` typed `device` as `Device[]` while it is a `Device` at runtime. It slipped past `tsc` because the conditional type degrades to `any` inside the class. The mistyping also hid a broken README example (`console.log(devices.name)` inside a `for await (const device …)` loop).

## Fix

`flatten()` now yields `ElementOfArray<TResponse[TResponseKey]>` — the item type. Runtime unchanged. Fixed the README example to `device.display_name`.

## Tests

The flatten test now pins the element type: `expectType<Device>(device)` compiles and `expectType<Device[]>(device)` is a `@ts-expect-error`. On reverted source, typecheck fails with 3 errors — the audit's exact symptom. Full suite (125 tests), lint, typecheck green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_