### PR TITLE
feat: Only accept paginated requests in createPaginator

### DIFF
--- a/codegen/layouts/partials/route-class-endpoint-export.hbs
+++ b/codegen/layouts/partials/route-class-endpoint-export.hbs
@@ -5,7 +5,7 @@ export type {{parametersTypeName}} = {{#if requiresAtLeastOneParameter}}RequireA
  */
 export type {{responseTypeName}} = {{#if returnsVoid}}void{{else}}{ {{json responseKey}}: {{#if responseIsList}}Array<{{responseResourceTypeName}}>{{else}}{{responseResourceTypeName}}{{/if}} }{{/if}}
 
-export type {{requestTypeName}} = SeamHttpRequest<{{#if returnsVoid}}void, undefined{{else}}{{responseTypeName}}, '{{responseKey}}'{{/if}}{{#if hasPagination}}, true{{/if}}>
+export type {{requestTypeName}} = {{#if hasPagination}}SeamPaginatedRequest<{{responseTypeName}}, '{{responseKey}}'>{{else}}SeamHttpRequest<{{#if returnsVoid}}void, undefined{{else}}{{responseTypeName}}, '{{responseKey}}'{{/if}}>{{/if}}
 
 
 {{#if returnsActionAttempt}}

--- a/codegen/layouts/partials/route-class-endpoint-export.hbs
+++ b/codegen/layouts/partials/route-class-endpoint-export.hbs
@@ -5,7 +5,7 @@ export type {{parametersTypeName}} = {{#if requiresAtLeastOneParameter}}RequireA
  */
 export type {{responseTypeName}} = {{#if returnsVoid}}void{{else}}{ {{json responseKey}}: {{#if responseIsList}}Array<{{responseResourceTypeName}}>{{else}}{{responseResourceTypeName}}{{/if}} }{{/if}}
 
-export type {{requestTypeName}} = SeamHttpRequest<{{#if returnsVoid}}void, undefined{{else}}{{responseTypeName}}, '{{responseKey}}'{{/if}}>
+export type {{requestTypeName}} = SeamHttpRequest<{{#if returnsVoid}}void, undefined{{else}}{{responseTypeName}}, '{{responseKey}}'{{/if}}{{#if hasPagination}}, true{{/if}}>
 
 
 {{#if returnsActionAttempt}}

--- a/codegen/layouts/partials/route-class-methods.hbs
+++ b/codegen/layouts/partials/route-class-methods.hbs
@@ -98,7 +98,7 @@ static fromPersonalAccessToken(
 }
 
 createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-  request: SeamHttpRequest<TResponse, TResponseKey>,
+  request: SeamHttpRequest<TResponse, TResponseKey, true>,
 ): SeamPaginator<TResponse, TResponseKey> {
   return new SeamPaginator<TResponse, TResponseKey>(this, request)
 }

--- a/codegen/layouts/partials/route-class-methods.hbs
+++ b/codegen/layouts/partials/route-class-methods.hbs
@@ -98,7 +98,7 @@ static fromPersonalAccessToken(
 }
 
 createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-  request: SeamHttpRequest<TResponse, TResponseKey, true>,
+  request: SeamPaginatedRequest<TResponse, TResponseKey>,
 ): SeamPaginator<TResponse, TResponseKey> {
   return new SeamPaginator<TResponse, TResponseKey>(this, request)
 }

--- a/codegen/layouts/partials/route-imports.hbs
+++ b/codegen/layouts/partials/route-imports.hbs
@@ -31,7 +31,10 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions
 } from 'lib/parse-options.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  type SeamPaginatedRequest,
+  SeamHttpRequest
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 {{#if needsActionAttemptsImport}}

--- a/src/lib/routes/access-codes/access-codes.ts
+++ b/src/lib/routes/access-codes/access-codes.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AccessCode } from 'lib/resources/access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAccessCodesSimulate } from './simulate/index.js'
@@ -138,7 +141,7 @@ export class SeamHttpAccessCodes {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -662,10 +665,9 @@ export type AccessCodesListParameters = RequireAtLeastOne<{
  */
 export type AccessCodesListResponse = { access_codes: Array<AccessCode> }
 
-export type AccessCodesListRequest = SeamHttpRequest<
+export type AccessCodesListRequest = SeamPaginatedRequest<
   AccessCodesListResponse,
-  'access_codes',
-  true
+  'access_codes'
 >
 
 export interface AccessCodesListOptions {}

--- a/src/lib/routes/access-codes/access-codes.ts
+++ b/src/lib/routes/access-codes/access-codes.ts
@@ -138,7 +138,7 @@ export class SeamHttpAccessCodes {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -664,7 +664,8 @@ export type AccessCodesListResponse = { access_codes: Array<AccessCode> }
 
 export type AccessCodesListRequest = SeamHttpRequest<
   AccessCodesListResponse,
-  'access_codes'
+  'access_codes',
+  true
 >
 
 export interface AccessCodesListOptions {}

--- a/src/lib/routes/access-codes/simulate/simulate.ts
+++ b/src/lib/routes/access-codes/simulate/simulate.ts
@@ -134,7 +134,7 @@ export class SeamHttpAccessCodesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/access-codes/simulate/simulate.ts
+++ b/src/lib/routes/access-codes/simulate/simulate.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { UnmanagedAccessCode } from 'lib/resources/unmanaged-access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAccessCodesSimulate {
@@ -134,7 +137,7 @@ export class SeamHttpAccessCodesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/access-codes/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-codes/unmanaged/unmanaged.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { UnmanagedAccessCode } from 'lib/resources/unmanaged-access-code.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAccessCodesUnmanaged {
@@ -135,7 +138,7 @@ export class SeamHttpAccessCodesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -370,10 +373,9 @@ export type AccessCodesUnmanagedListResponse = {
   access_codes: Array<UnmanagedAccessCode>
 }
 
-export type AccessCodesUnmanagedListRequest = SeamHttpRequest<
+export type AccessCodesUnmanagedListRequest = SeamPaginatedRequest<
   AccessCodesUnmanagedListResponse,
-  'access_codes',
-  true
+  'access_codes'
 >
 
 export interface AccessCodesUnmanagedListOptions {}

--- a/src/lib/routes/access-codes/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-codes/unmanaged/unmanaged.ts
@@ -135,7 +135,7 @@ export class SeamHttpAccessCodesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -372,7 +372,8 @@ export type AccessCodesUnmanagedListResponse = {
 
 export type AccessCodesUnmanagedListRequest = SeamHttpRequest<
   AccessCodesUnmanagedListResponse,
-  'access_codes'
+  'access_codes',
+  true
 >
 
 export interface AccessCodesUnmanagedListOptions {}

--- a/src/lib/routes/access-grants/access-grants.ts
+++ b/src/lib/routes/access-grants/access-grants.ts
@@ -138,7 +138,7 @@ export class SeamHttpAccessGrants {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -583,7 +583,8 @@ export type AccessGrantsListResponse = { access_grants: Array<AccessGrant> }
 
 export type AccessGrantsListRequest = SeamHttpRequest<
   AccessGrantsListResponse,
-  'access_grants'
+  'access_grants',
+  true
 >
 
 export interface AccessGrantsListOptions {}

--- a/src/lib/routes/access-grants/access-grants.ts
+++ b/src/lib/routes/access-grants/access-grants.ts
@@ -32,7 +32,10 @@ import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AccessGrant } from 'lib/resources/access-grant.js'
 import type { Batch } from 'lib/resources/batch.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAccessGrantsUnmanaged } from './unmanaged/index.js'
@@ -138,7 +141,7 @@ export class SeamHttpAccessGrants {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -581,10 +584,9 @@ export type AccessGrantsListParameters = {
  */
 export type AccessGrantsListResponse = { access_grants: Array<AccessGrant> }
 
-export type AccessGrantsListRequest = SeamHttpRequest<
+export type AccessGrantsListRequest = SeamPaginatedRequest<
   AccessGrantsListResponse,
-  'access_grants',
-  true
+  'access_grants'
 >
 
 export interface AccessGrantsListOptions {}

--- a/src/lib/routes/access-grants/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-grants/unmanaged/unmanaged.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { UnmanagedAccessGrant } from 'lib/resources/unmanaged-access-grant.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAccessGrantsUnmanaged {
@@ -134,7 +137,7 @@ export class SeamHttpAccessGrantsUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -276,10 +279,9 @@ export type AccessGrantsUnmanagedListResponse = {
   access_grants: Array<UnmanagedAccessGrant>
 }
 
-export type AccessGrantsUnmanagedListRequest = SeamHttpRequest<
+export type AccessGrantsUnmanagedListRequest = SeamPaginatedRequest<
   AccessGrantsUnmanagedListResponse,
-  'access_grants',
-  true
+  'access_grants'
 >
 
 export interface AccessGrantsUnmanagedListOptions {}

--- a/src/lib/routes/access-grants/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-grants/unmanaged/unmanaged.ts
@@ -134,7 +134,7 @@ export class SeamHttpAccessGrantsUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -278,7 +278,8 @@ export type AccessGrantsUnmanagedListResponse = {
 
 export type AccessGrantsUnmanagedListRequest = SeamHttpRequest<
   AccessGrantsUnmanagedListResponse,
-  'access_grants'
+  'access_grants',
+  true
 >
 
 export interface AccessGrantsUnmanagedListOptions {}

--- a/src/lib/routes/access-methods/access-methods.ts
+++ b/src/lib/routes/access-methods/access-methods.ts
@@ -34,7 +34,10 @@ import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Batch } from 'lib/resources/batch.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAccessMethodsUnmanaged } from './unmanaged/index.js'
@@ -140,7 +143,7 @@ export class SeamHttpAccessMethods {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -508,10 +511,9 @@ export type AccessMethodsListParameters = RequireAtLeastOne<{
  */
 export type AccessMethodsListResponse = { access_methods: Array<AccessMethod> }
 
-export type AccessMethodsListRequest = SeamHttpRequest<
+export type AccessMethodsListRequest = SeamPaginatedRequest<
   AccessMethodsListResponse,
-  'access_methods',
-  true
+  'access_methods'
 >
 
 export interface AccessMethodsListOptions {}

--- a/src/lib/routes/access-methods/access-methods.ts
+++ b/src/lib/routes/access-methods/access-methods.ts
@@ -140,7 +140,7 @@ export class SeamHttpAccessMethods {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -510,7 +510,8 @@ export type AccessMethodsListResponse = { access_methods: Array<AccessMethod> }
 
 export type AccessMethodsListRequest = SeamHttpRequest<
   AccessMethodsListResponse,
-  'access_methods'
+  'access_methods',
+  true
 >
 
 export interface AccessMethodsListOptions {}

--- a/src/lib/routes/access-methods/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-methods/unmanaged/unmanaged.ts
@@ -134,7 +134,7 @@ export class SeamHttpAccessMethodsUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/access-methods/unmanaged/unmanaged.ts
+++ b/src/lib/routes/access-methods/unmanaged/unmanaged.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { UnmanagedAccessMethod } from 'lib/resources/unmanaged-access-method.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAccessMethodsUnmanaged {
@@ -134,7 +137,7 @@ export class SeamHttpAccessMethodsUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/access-groups/access-groups.ts
+++ b/src/lib/routes/acs/access-groups/access-groups.ts
@@ -32,7 +32,10 @@ import type { AcsAccessGroup } from 'lib/resources/acs-access-group.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { AcsUser } from 'lib/resources/acs-user.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsAccessGroups {
@@ -136,7 +139,7 @@ export class SeamHttpAcsAccessGroups {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/access-groups/access-groups.ts
+++ b/src/lib/routes/acs/access-groups/access-groups.ts
@@ -136,7 +136,7 @@ export class SeamHttpAcsAccessGroups {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/acs.ts
+++ b/src/lib/routes/acs/acs.ts
@@ -140,7 +140,7 @@ export class SeamHttpAcs {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/acs.ts
+++ b/src/lib/routes/acs/acs.ts
@@ -29,7 +29,7 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import type { SeamHttpRequest } from 'lib/seam-http-request.js'
+import type { SeamPaginatedRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAcsAccessGroups } from './access-groups/index.js'
@@ -140,7 +140,7 @@ export class SeamHttpAcs {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/credentials/credentials.ts
+++ b/src/lib/routes/acs/credentials/credentials.ts
@@ -135,7 +135,7 @@ export class SeamHttpAcsCredentials {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -514,7 +514,8 @@ export type AcsCredentialsListResponse = {
 
 export type AcsCredentialsListRequest = SeamHttpRequest<
   AcsCredentialsListResponse,
-  'acs_credentials'
+  'acs_credentials',
+  true
 >
 
 export interface AcsCredentialsListOptions {}

--- a/src/lib/routes/acs/credentials/credentials.ts
+++ b/src/lib/routes/acs/credentials/credentials.ts
@@ -31,7 +31,10 @@ import {
 import type { AcsCredential } from 'lib/resources/acs-credential.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsCredentials {
@@ -135,7 +138,7 @@ export class SeamHttpAcsCredentials {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -512,10 +515,9 @@ export type AcsCredentialsListResponse = {
   acs_credentials: Array<AcsCredential>
 }
 
-export type AcsCredentialsListRequest = SeamHttpRequest<
+export type AcsCredentialsListRequest = SeamPaginatedRequest<
   AcsCredentialsListResponse,
-  'acs_credentials',
-  true
+  'acs_credentials'
 >
 
 export interface AcsCredentialsListOptions {}

--- a/src/lib/routes/acs/encoders/encoders.ts
+++ b/src/lib/routes/acs/encoders/encoders.ts
@@ -32,7 +32,10 @@ import type { AcsEncoder } from 'lib/resources/acs-encoder.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAcsEncodersSimulate } from './simulate/index.js'
@@ -138,7 +141,7 @@ export class SeamHttpAcsEncoders {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -354,10 +357,9 @@ export type AcsEncodersListParameters = {
  */
 export type AcsEncodersListResponse = { acs_encoders: Array<AcsEncoder> }
 
-export type AcsEncodersListRequest = SeamHttpRequest<
+export type AcsEncodersListRequest = SeamPaginatedRequest<
   AcsEncodersListResponse,
-  'acs_encoders',
-  true
+  'acs_encoders'
 >
 
 export interface AcsEncodersListOptions {}

--- a/src/lib/routes/acs/encoders/encoders.ts
+++ b/src/lib/routes/acs/encoders/encoders.ts
@@ -138,7 +138,7 @@ export class SeamHttpAcsEncoders {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -356,7 +356,8 @@ export type AcsEncodersListResponse = { acs_encoders: Array<AcsEncoder> }
 
 export type AcsEncodersListRequest = SeamHttpRequest<
   AcsEncodersListResponse,
-  'acs_encoders'
+  'acs_encoders',
+  true
 >
 
 export interface AcsEncodersListOptions {}

--- a/src/lib/routes/acs/encoders/simulate/simulate.ts
+++ b/src/lib/routes/acs/encoders/simulate/simulate.ts
@@ -29,7 +29,10 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsEncodersSimulate {
@@ -133,7 +136,7 @@ export class SeamHttpAcsEncodersSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/encoders/simulate/simulate.ts
+++ b/src/lib/routes/acs/encoders/simulate/simulate.ts
@@ -133,7 +133,7 @@ export class SeamHttpAcsEncodersSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/entrances/entrances.ts
+++ b/src/lib/routes/acs/entrances/entrances.ts
@@ -33,7 +33,10 @@ import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsEntrances {
@@ -137,7 +140,7 @@ export class SeamHttpAcsEntrances {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -358,10 +361,9 @@ export type AcsEntrancesListParameters = {
  */
 export type AcsEntrancesListResponse = { acs_entrances: Array<AcsEntrance> }
 
-export type AcsEntrancesListRequest = SeamHttpRequest<
+export type AcsEntrancesListRequest = SeamPaginatedRequest<
   AcsEntrancesListResponse,
-  'acs_entrances',
-  true
+  'acs_entrances'
 >
 
 export interface AcsEntrancesListOptions {}

--- a/src/lib/routes/acs/entrances/entrances.ts
+++ b/src/lib/routes/acs/entrances/entrances.ts
@@ -137,7 +137,7 @@ export class SeamHttpAcsEntrances {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -360,7 +360,8 @@ export type AcsEntrancesListResponse = { acs_entrances: Array<AcsEntrance> }
 
 export type AcsEntrancesListRequest = SeamHttpRequest<
   AcsEntrancesListResponse,
-  'acs_entrances'
+  'acs_entrances',
+  true
 >
 
 export interface AcsEntrancesListOptions {}

--- a/src/lib/routes/acs/systems/systems.ts
+++ b/src/lib/routes/acs/systems/systems.ts
@@ -134,7 +134,7 @@ export class SeamHttpAcsSystems {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/systems/systems.ts
+++ b/src/lib/routes/acs/systems/systems.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { AcsSystem } from 'lib/resources/acs-system.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsSystems {
@@ -134,7 +137,7 @@ export class SeamHttpAcsSystems {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/acs/users/users.ts
+++ b/src/lib/routes/acs/users/users.ts
@@ -32,7 +32,10 @@ import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { AcsEntrance } from 'lib/resources/acs-entrance.js'
 import type { AcsUser } from 'lib/resources/acs-user.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpAcsUsers {
@@ -136,7 +139,7 @@ export class SeamHttpAcsUsers {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -543,10 +546,9 @@ export type AcsUsersListParameters = {
  */
 export type AcsUsersListResponse = { acs_users: Array<AcsUser> }
 
-export type AcsUsersListRequest = SeamHttpRequest<
+export type AcsUsersListRequest = SeamPaginatedRequest<
   AcsUsersListResponse,
-  'acs_users',
-  true
+  'acs_users'
 >
 
 export interface AcsUsersListOptions {}

--- a/src/lib/routes/acs/users/users.ts
+++ b/src/lib/routes/acs/users/users.ts
@@ -136,7 +136,7 @@ export class SeamHttpAcsUsers {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -545,7 +545,8 @@ export type AcsUsersListResponse = { acs_users: Array<AcsUser> }
 
 export type AcsUsersListRequest = SeamHttpRequest<
   AcsUsersListResponse,
-  'acs_users'
+  'acs_users',
+  true
 >
 
 export interface AcsUsersListOptions {}

--- a/src/lib/routes/action-attempts/action-attempts.ts
+++ b/src/lib/routes/action-attempts/action-attempts.ts
@@ -134,7 +134,7 @@ export class SeamHttpActionAttempts {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -252,7 +252,8 @@ export type ActionAttemptsListResponse = {
 
 export type ActionAttemptsListRequest = SeamHttpRequest<
   ActionAttemptsListResponse,
-  'action_attempts'
+  'action_attempts',
+  true
 >
 
 export interface ActionAttemptsListOptions {}

--- a/src/lib/routes/action-attempts/action-attempts.ts
+++ b/src/lib/routes/action-attempts/action-attempts.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpActionAttempts {
@@ -134,7 +137,7 @@ export class SeamHttpActionAttempts {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -250,10 +253,9 @@ export type ActionAttemptsListResponse = {
   action_attempts: Array<ActionAttempt>
 }
 
-export type ActionAttemptsListRequest = SeamHttpRequest<
+export type ActionAttemptsListRequest = SeamPaginatedRequest<
   ActionAttemptsListResponse,
-  'action_attempts',
-  true
+  'action_attempts'
 >
 
 export interface ActionAttemptsListOptions {}

--- a/src/lib/routes/client-sessions/client-sessions.ts
+++ b/src/lib/routes/client-sessions/client-sessions.ts
@@ -134,7 +134,7 @@ export class SeamHttpClientSessions {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/client-sessions/client-sessions.ts
+++ b/src/lib/routes/client-sessions/client-sessions.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { ClientSession } from 'lib/resources/client-session.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpClientSessions {
@@ -134,7 +137,7 @@ export class SeamHttpClientSessions {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/connect-webviews/connect-webviews.ts
+++ b/src/lib/routes/connect-webviews/connect-webviews.ts
@@ -134,7 +134,7 @@ export class SeamHttpConnectWebviews {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -457,7 +457,8 @@ export type ConnectWebviewsListResponse = {
 
 export type ConnectWebviewsListRequest = SeamHttpRequest<
   ConnectWebviewsListResponse,
-  'connect_webviews'
+  'connect_webviews',
+  true
 >
 
 export interface ConnectWebviewsListOptions {}

--- a/src/lib/routes/connect-webviews/connect-webviews.ts
+++ b/src/lib/routes/connect-webviews/connect-webviews.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { ConnectWebview } from 'lib/resources/connect-webview.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpConnectWebviews {
@@ -134,7 +137,7 @@ export class SeamHttpConnectWebviews {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -455,10 +458,9 @@ export type ConnectWebviewsListResponse = {
   connect_webviews: Array<ConnectWebview>
 }
 
-export type ConnectWebviewsListRequest = SeamHttpRequest<
+export type ConnectWebviewsListRequest = SeamPaginatedRequest<
   ConnectWebviewsListResponse,
-  'connect_webviews',
-  true
+  'connect_webviews'
 >
 
 export interface ConnectWebviewsListOptions {}

--- a/src/lib/routes/connected-accounts/connected-accounts.ts
+++ b/src/lib/routes/connected-accounts/connected-accounts.ts
@@ -137,7 +137,7 @@ export class SeamHttpConnectedAccounts {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -350,7 +350,8 @@ export type ConnectedAccountsListResponse = {
 
 export type ConnectedAccountsListRequest = SeamHttpRequest<
   ConnectedAccountsListResponse,
-  'connected_accounts'
+  'connected_accounts',
+  true
 >
 
 export interface ConnectedAccountsListOptions {}

--- a/src/lib/routes/connected-accounts/connected-accounts.ts
+++ b/src/lib/routes/connected-accounts/connected-accounts.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { ConnectedAccount } from 'lib/resources/connected-account.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpConnectedAccountsSimulate } from './simulate/index.js'
@@ -137,7 +140,7 @@ export class SeamHttpConnectedAccounts {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -348,10 +351,9 @@ export type ConnectedAccountsListResponse = {
   connected_accounts: Array<ConnectedAccount>
 }
 
-export type ConnectedAccountsListRequest = SeamHttpRequest<
+export type ConnectedAccountsListRequest = SeamPaginatedRequest<
   ConnectedAccountsListResponse,
-  'connected_accounts',
-  true
+  'connected_accounts'
 >
 
 export interface ConnectedAccountsListOptions {}

--- a/src/lib/routes/connected-accounts/simulate/simulate.ts
+++ b/src/lib/routes/connected-accounts/simulate/simulate.ts
@@ -136,7 +136,7 @@ export class SeamHttpConnectedAccountsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/connected-accounts/simulate/simulate.ts
+++ b/src/lib/routes/connected-accounts/simulate/simulate.ts
@@ -29,7 +29,10 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpConnectedAccountsSimulate {
@@ -136,7 +139,7 @@ export class SeamHttpConnectedAccountsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/customers/customers.ts
+++ b/src/lib/routes/customers/customers.ts
@@ -134,7 +134,7 @@ export class SeamHttpCustomers {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/customers/customers.ts
+++ b/src/lib/routes/customers/customers.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { CustomerPortal } from 'lib/resources/customer-portal.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpCustomers {
@@ -134,7 +137,7 @@ export class SeamHttpCustomers {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/devices/devices.ts
+++ b/src/lib/routes/devices/devices.ts
@@ -139,7 +139,7 @@ export class SeamHttpDevices {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -511,7 +511,11 @@ export type DevicesListParameters = {
  */
 export type DevicesListResponse = { devices: Array<Device> }
 
-export type DevicesListRequest = SeamHttpRequest<DevicesListResponse, 'devices'>
+export type DevicesListRequest = SeamHttpRequest<
+  DevicesListResponse,
+  'devices',
+  true
+>
 
 export interface DevicesListOptions {}
 

--- a/src/lib/routes/devices/devices.ts
+++ b/src/lib/routes/devices/devices.ts
@@ -32,7 +32,10 @@ import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { Device } from 'lib/resources/device.js'
 import type { DeviceProvider } from 'lib/resources/device-provider.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpDevicesSimulate } from './simulate/index.js'
@@ -139,7 +142,7 @@ export class SeamHttpDevices {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -511,10 +514,9 @@ export type DevicesListParameters = {
  */
 export type DevicesListResponse = { devices: Array<Device> }
 
-export type DevicesListRequest = SeamHttpRequest<
+export type DevicesListRequest = SeamPaginatedRequest<
   DevicesListResponse,
-  'devices',
-  true
+  'devices'
 >
 
 export interface DevicesListOptions {}

--- a/src/lib/routes/devices/simulate/simulate.ts
+++ b/src/lib/routes/devices/simulate/simulate.ts
@@ -133,7 +133,7 @@ export class SeamHttpDevicesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/devices/simulate/simulate.ts
+++ b/src/lib/routes/devices/simulate/simulate.ts
@@ -29,7 +29,10 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpDevicesSimulate {
@@ -133,7 +136,7 @@ export class SeamHttpDevicesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/devices/unmanaged/unmanaged.ts
+++ b/src/lib/routes/devices/unmanaged/unmanaged.ts
@@ -135,7 +135,7 @@ export class SeamHttpDevicesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -450,7 +450,8 @@ export type DevicesUnmanagedListResponse = { devices: Array<UnmanagedDevice> }
 
 export type DevicesUnmanagedListRequest = SeamHttpRequest<
   DevicesUnmanagedListResponse,
-  'devices'
+  'devices',
+  true
 >
 
 export interface DevicesUnmanagedListOptions {}

--- a/src/lib/routes/devices/unmanaged/unmanaged.ts
+++ b/src/lib/routes/devices/unmanaged/unmanaged.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { UnmanagedDevice } from 'lib/resources/unmanaged-device.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpDevicesUnmanaged {
@@ -135,7 +138,7 @@ export class SeamHttpDevicesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -448,10 +451,9 @@ export type DevicesUnmanagedListParameters = {
  */
 export type DevicesUnmanagedListResponse = { devices: Array<UnmanagedDevice> }
 
-export type DevicesUnmanagedListRequest = SeamHttpRequest<
+export type DevicesUnmanagedListRequest = SeamPaginatedRequest<
   DevicesUnmanagedListResponse,
-  'devices',
-  true
+  'devices'
 >
 
 export interface DevicesUnmanagedListOptions {}

--- a/src/lib/routes/events/events.ts
+++ b/src/lib/routes/events/events.ts
@@ -135,7 +135,7 @@ export class SeamHttpEvents {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/events/events.ts
+++ b/src/lib/routes/events/events.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { SeamEvent } from 'lib/resources/event.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpEvents {
@@ -135,7 +138,7 @@ export class SeamHttpEvents {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/instant-keys/instant-keys.ts
+++ b/src/lib/routes/instant-keys/instant-keys.ts
@@ -135,7 +135,7 @@ export class SeamHttpInstantKeys {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/instant-keys/instant-keys.ts
+++ b/src/lib/routes/instant-keys/instant-keys.ts
@@ -31,7 +31,10 @@ import {
 import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { InstantKey } from 'lib/resources/instant-key.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpInstantKeys {
@@ -135,7 +138,7 @@ export class SeamHttpInstantKeys {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/locks/locks.ts
+++ b/src/lib/routes/locks/locks.ts
@@ -33,7 +33,10 @@ import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpLocksSimulate } from './simulate/index.js'
@@ -139,7 +142,7 @@ export class SeamHttpLocks {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/locks/locks.ts
+++ b/src/lib/routes/locks/locks.ts
@@ -139,7 +139,7 @@ export class SeamHttpLocks {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/locks/simulate/simulate.ts
+++ b/src/lib/routes/locks/simulate/simulate.ts
@@ -31,7 +31,10 @@ import {
 import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpLocksSimulate {
@@ -135,7 +138,7 @@ export class SeamHttpLocksSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/locks/simulate/simulate.ts
+++ b/src/lib/routes/locks/simulate/simulate.ts
@@ -135,7 +135,7 @@ export class SeamHttpLocksSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/noise-sensors.ts
+++ b/src/lib/routes/noise-sensors/noise-sensors.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpNoiseSensorsNoiseThresholds } from './noise-thresholds/index.js'
@@ -137,7 +140,7 @@ export class SeamHttpNoiseSensors {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/noise-sensors.ts
+++ b/src/lib/routes/noise-sensors/noise-sensors.ts
@@ -137,7 +137,7 @@ export class SeamHttpNoiseSensors {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
+++ b/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
@@ -137,7 +137,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
+++ b/src/lib/routes/noise-sensors/noise-thresholds/noise-thresholds.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { NoiseThreshold } from 'lib/resources/noise-threshold.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpNoiseSensorsNoiseThresholds {
@@ -137,7 +140,7 @@ export class SeamHttpNoiseSensorsNoiseThresholds {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/simulate/simulate.ts
+++ b/src/lib/routes/noise-sensors/simulate/simulate.ts
@@ -29,7 +29,10 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpNoiseSensorsSimulate {
@@ -133,7 +136,7 @@ export class SeamHttpNoiseSensorsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/noise-sensors/simulate/simulate.ts
+++ b/src/lib/routes/noise-sensors/simulate/simulate.ts
@@ -133,7 +133,7 @@ export class SeamHttpNoiseSensorsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/phones/phones.ts
+++ b/src/lib/routes/phones/phones.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { Phone } from 'lib/resources/phone.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpPhonesSimulate } from './simulate/index.js'
@@ -136,7 +139,7 @@ export class SeamHttpPhones {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/phones/phones.ts
+++ b/src/lib/routes/phones/phones.ts
@@ -136,7 +136,7 @@ export class SeamHttpPhones {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/phones/simulate/simulate.ts
+++ b/src/lib/routes/phones/simulate/simulate.ts
@@ -134,7 +134,7 @@ export class SeamHttpPhonesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/phones/simulate/simulate.ts
+++ b/src/lib/routes/phones/simulate/simulate.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { Phone } from 'lib/resources/phone.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpPhonesSimulate {
@@ -134,7 +137,7 @@ export class SeamHttpPhonesSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/seam-http-endpoints.ts
+++ b/src/lib/routes/seam-http-endpoints.ts
@@ -28,7 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import type { SeamHttpRequest } from 'lib/seam-http-request.js'
+import type { SeamPaginatedRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import {
@@ -862,7 +862,7 @@ export class SeamHttpEndpoints {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/seam-http-endpoints.ts
+++ b/src/lib/routes/seam-http-endpoints.ts
@@ -862,7 +862,7 @@ export class SeamHttpEndpoints {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/seam-http.ts
+++ b/src/lib/routes/seam-http.ts
@@ -153,7 +153,7 @@ export class SeamHttp {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/seam-http.ts
+++ b/src/lib/routes/seam-http.ts
@@ -28,7 +28,7 @@ import {
   limitToSeamHttpRequestOptions,
   parseOptions,
 } from 'lib/parse-options.js'
-import type { SeamHttpRequest } from 'lib/seam-http-request.js'
+import type { SeamPaginatedRequest } from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpAccessCodes } from './access-codes/index.js'
@@ -153,7 +153,7 @@ export class SeamHttp {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/spaces/spaces.ts
+++ b/src/lib/routes/spaces/spaces.ts
@@ -136,7 +136,7 @@ export class SeamHttpSpaces {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -630,7 +630,11 @@ export type SpacesListParameters = {
  */
 export type SpacesListResponse = { spaces: Array<Space> }
 
-export type SpacesListRequest = SeamHttpRequest<SpacesListResponse, 'spaces'>
+export type SpacesListRequest = SeamHttpRequest<
+  SpacesListResponse,
+  'spaces',
+  true
+>
 
 export interface SpacesListOptions {}
 

--- a/src/lib/routes/spaces/spaces.ts
+++ b/src/lib/routes/spaces/spaces.ts
@@ -32,7 +32,10 @@ import type { RequireAtLeastOne } from 'lib/request-parameters.js'
 import type { Batch } from 'lib/resources/batch.js'
 import type { Space } from 'lib/resources/space.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpSpaces {
@@ -136,7 +139,7 @@ export class SeamHttpSpaces {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -630,10 +633,9 @@ export type SpacesListParameters = {
  */
 export type SpacesListResponse = { spaces: Array<Space> }
 
-export type SpacesListRequest = SeamHttpRequest<
+export type SpacesListRequest = SeamPaginatedRequest<
   SpacesListResponse,
-  'spaces',
-  true
+  'spaces'
 >
 
 export interface SpacesListOptions {}

--- a/src/lib/routes/thermostats/daily-programs/daily-programs.ts
+++ b/src/lib/routes/thermostats/daily-programs/daily-programs.ts
@@ -32,7 +32,10 @@ import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { ThermostatDailyProgram } from 'lib/resources/thermostat-daily-program.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpThermostatsDailyPrograms {
@@ -139,7 +142,7 @@ export class SeamHttpThermostatsDailyPrograms {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/daily-programs/daily-programs.ts
+++ b/src/lib/routes/thermostats/daily-programs/daily-programs.ts
@@ -139,7 +139,7 @@ export class SeamHttpThermostatsDailyPrograms {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/schedules/schedules.ts
+++ b/src/lib/routes/thermostats/schedules/schedules.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { ThermostatSchedule } from 'lib/resources/thermostat-schedule.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpThermostatsSchedules {
@@ -134,7 +137,7 @@ export class SeamHttpThermostatsSchedules {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/schedules/schedules.ts
+++ b/src/lib/routes/thermostats/schedules/schedules.ts
@@ -134,7 +134,7 @@ export class SeamHttpThermostatsSchedules {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/simulate/simulate.ts
+++ b/src/lib/routes/thermostats/simulate/simulate.ts
@@ -133,7 +133,7 @@ export class SeamHttpThermostatsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/simulate/simulate.ts
+++ b/src/lib/routes/thermostats/simulate/simulate.ts
@@ -29,7 +29,10 @@ import {
   parseOptions,
 } from 'lib/parse-options.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpThermostatsSimulate {
@@ -133,7 +136,7 @@ export class SeamHttpThermostatsSimulate {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/thermostats.ts
+++ b/src/lib/routes/thermostats/thermostats.ts
@@ -32,7 +32,10 @@ import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Device } from 'lib/resources/device.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpThermostatsDailyPrograms } from './daily-programs/index.js'
@@ -140,7 +143,7 @@ export class SeamHttpThermostats {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/thermostats/thermostats.ts
+++ b/src/lib/routes/thermostats/thermostats.ts
@@ -140,7 +140,7 @@ export class SeamHttpThermostats {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/user-identities/unmanaged/unmanaged.ts
+++ b/src/lib/routes/user-identities/unmanaged/unmanaged.ts
@@ -137,7 +137,7 @@ export class SeamHttpUserIdentitiesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -271,7 +271,8 @@ export type UserIdentitiesUnmanagedListResponse = {
 
 export type UserIdentitiesUnmanagedListRequest = SeamHttpRequest<
   UserIdentitiesUnmanagedListResponse,
-  'user_identities'
+  'user_identities',
+  true
 >
 
 export interface UserIdentitiesUnmanagedListOptions {}

--- a/src/lib/routes/user-identities/unmanaged/unmanaged.ts
+++ b/src/lib/routes/user-identities/unmanaged/unmanaged.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { UnmanagedUserIdentity } from 'lib/resources/unmanaged-user-identity.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpUserIdentitiesUnmanaged {
@@ -137,7 +140,7 @@ export class SeamHttpUserIdentitiesUnmanaged {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -269,10 +272,9 @@ export type UserIdentitiesUnmanagedListResponse = {
   user_identities: Array<UnmanagedUserIdentity>
 }
 
-export type UserIdentitiesUnmanagedListRequest = SeamHttpRequest<
+export type UserIdentitiesUnmanagedListRequest = SeamPaginatedRequest<
   UserIdentitiesUnmanagedListResponse,
-  'user_identities',
-  true
+  'user_identities'
 >
 
 export interface UserIdentitiesUnmanagedListOptions {}

--- a/src/lib/routes/user-identities/user-identities.ts
+++ b/src/lib/routes/user-identities/user-identities.ts
@@ -36,7 +36,10 @@ import type { Device } from 'lib/resources/device.js'
 import type { InstantKey } from 'lib/resources/instant-key.js'
 import type { UserIdentity } from 'lib/resources/user-identity.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 import { SeamHttpUserIdentitiesUnmanaged } from './unmanaged/index.js'
@@ -142,7 +145,7 @@ export class SeamHttpUserIdentities {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -651,10 +654,9 @@ export type UserIdentitiesListResponse = {
   user_identities: Array<UserIdentity>
 }
 
-export type UserIdentitiesListRequest = SeamHttpRequest<
+export type UserIdentitiesListRequest = SeamPaginatedRequest<
   UserIdentitiesListResponse,
-  'user_identities',
-  true
+  'user_identities'
 >
 
 export interface UserIdentitiesListOptions {}

--- a/src/lib/routes/user-identities/user-identities.ts
+++ b/src/lib/routes/user-identities/user-identities.ts
@@ -142,7 +142,7 @@ export class SeamHttpUserIdentities {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }
@@ -653,7 +653,8 @@ export type UserIdentitiesListResponse = {
 
 export type UserIdentitiesListRequest = SeamHttpRequest<
   UserIdentitiesListResponse,
-  'user_identities'
+  'user_identities',
+  true
 >
 
 export interface UserIdentitiesListOptions {}

--- a/src/lib/routes/webhooks/webhooks.ts
+++ b/src/lib/routes/webhooks/webhooks.ts
@@ -30,7 +30,10 @@ import {
 } from 'lib/parse-options.js'
 import type { Webhook } from 'lib/resources/webhook.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpWebhooks {
@@ -134,7 +137,7 @@ export class SeamHttpWebhooks {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/webhooks/webhooks.ts
+++ b/src/lib/routes/webhooks/webhooks.ts
@@ -134,7 +134,7 @@ export class SeamHttpWebhooks {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/workspaces/workspaces.ts
+++ b/src/lib/routes/workspaces/workspaces.ts
@@ -136,7 +136,7 @@ export class SeamHttpWorkspaces {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/routes/workspaces/workspaces.ts
+++ b/src/lib/routes/workspaces/workspaces.ts
@@ -32,7 +32,10 @@ import type { ActionAttempt } from 'lib/resources/action-attempt.js'
 import type { Workspace } from 'lib/resources/workspace.js'
 import { SeamHttpActionAttempts } from 'lib/routes/action-attempts/index.js'
 import { SeamHttpClientSessions } from 'lib/routes/client-sessions/index.js'
-import { SeamHttpRequest } from 'lib/seam-http-request.js'
+import {
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from 'lib/seam-http-request.js'
 import { SeamPaginator } from 'lib/seam-paginator.js'
 
 export class SeamHttpWorkspaces {
@@ -136,7 +139,7 @@ export class SeamHttpWorkspaces {
   }
 
   createPaginator<const TResponse, const TResponseKey extends keyof TResponse>(
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ): SeamPaginator<TResponse, TResponseKey> {
     return new SeamPaginator<TResponse, TResponseKey>(this, request)
   }

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -46,6 +46,7 @@ interface SeamHttpRequestConfig<TResponseKey> {
 export class SeamHttpRequest<
   const TResponse,
   const TResponseKey extends keyof TResponse | undefined,
+  const THasPagination extends boolean = boolean,
 > implements Promise<
   TResponseKey extends keyof TResponse ? TResponse[TResponseKey] : undefined
 > {
@@ -70,8 +71,8 @@ export class SeamHttpRequest<
     return this.#config.responseKey
   }
 
-  public get hasPagination(): boolean {
-    return this.#config.hasPagination ?? false
+  public get hasPagination(): THasPagination {
+    return (this.#config.hasPagination ?? false) as THasPagination
   }
 
   /**

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -258,6 +258,15 @@ export class SeamHttpRequest<
 }
 
 /**
+ * A SeamHttpRequest for an endpoint that supports pagination.
+ * Only these requests are accepted by `createPaginator`.
+ */
+export type SeamPaginatedRequest<
+  TResponse,
+  TResponseKey extends keyof TResponse | undefined,
+> = SeamHttpRequest<TResponse, TResponseKey, true>
+
+/**
  * Reads the response data at the response key,
  * throwing a {@link SeamHttpInvalidResponseError} for a success response
  * that is not an object or does not contain the response key.

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -259,7 +259,6 @@ export class SeamHttpRequest<
 
 /**
  * A SeamHttpRequest for an endpoint that supports pagination.
- * Only these requests are accepted by `createPaginator`.
  */
 export type SeamPaginatedRequest<
   TResponse,

--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -1,7 +1,11 @@
 import type { Client } from './client.js'
 import type { SeamHttpRequestOptions } from './options.js'
 import { SeamHttpInvalidResponseError } from './seam-http-error.js'
-import { readResponseData, SeamHttpRequest } from './seam-http-request.js'
+import {
+  readResponseData,
+  SeamHttpRequest,
+  type SeamPaginatedRequest,
+} from './seam-http-request.js'
 
 interface SeamPaginatorParent {
   readonly client: Client
@@ -34,12 +38,12 @@ export class SeamPaginator<
   const TResponse,
   const TResponseKey extends keyof TResponse,
 > implements AsyncIterable<EnsureReadonlyArray<TResponse[TResponseKey]>> {
-  readonly #request: SeamHttpRequest<TResponse, TResponseKey, true>
+  readonly #request: SeamPaginatedRequest<TResponse, TResponseKey>
   readonly #parent: SeamPaginatorParent
 
   constructor(
     parent: SeamPaginatorParent,
-    request: SeamHttpRequest<TResponse, TResponseKey, true>,
+    request: SeamPaginatedRequest<TResponse, TResponseKey>,
   ) {
     if (!request.hasPagination) {
       throw new Error(

--- a/src/lib/seam-paginator.ts
+++ b/src/lib/seam-paginator.ts
@@ -33,12 +33,12 @@ export class SeamPaginator<
   const TResponse,
   const TResponseKey extends keyof TResponse,
 > implements AsyncIterable<EnsureReadonlyArray<TResponse[TResponseKey]>> {
-  readonly #request: SeamHttpRequest<TResponse, TResponseKey>
+  readonly #request: SeamHttpRequest<TResponse, TResponseKey, true>
   readonly #parent: SeamPaginatorParent
 
   constructor(
     parent: SeamPaginatorParent,
-    request: SeamHttpRequest<TResponse, TResponseKey>,
+    request: SeamHttpRequest<TResponse, TResponseKey, true>,
   ) {
     if (!request.hasPagination) {
       throw new Error(

--- a/test/seam/connect/seam-paginator.test.ts
+++ b/test/seam/connect/seam-paginator.test.ts
@@ -28,9 +28,32 @@ test('SeamPaginator: cannot paginate a request that does not return pagination d
   const { seed, endpoint } = await getTestServer(t)
   const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
 
-  t.throws(() => seam.createPaginator(seam.workspaces.list()), {
-    message: /does not support pagination/,
-  })
+  t.throws(
+    () =>
+      seam.createPaginator(
+        // @ts-expect-error Verify only paginated requests are accepted.
+        seam.workspaces.list(),
+      ),
+    {
+      message: /does not support pagination/,
+    },
+  )
+})
+
+test('SeamPaginator: only accepts paginated requests at the type level', async (t) => {
+  const { seed, endpoint } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, { endpoint })
+
+  const assertOnlyPaginatedRequestsAccepted = (): void => {
+    seam.createPaginator(seam.devices.list())
+
+    seam.createPaginator(
+      // @ts-expect-error A non-paginated request is rejected at compile time.
+      seam.devices.get({ device_id: 'device-id' }),
+    )
+  }
+
+  t.is(typeof assertOnlyPaginatedRequestsAccepted, 'function')
 })
 
 test('SeamPaginator: firstPage returns the first page', async (t) => {


### PR DESCRIPTION
## Problem

SDK audit finding M11b (medium): `createPaginator` accepted any `SeamHttpRequest`, so `seam.createPaginator(seam.devices.get({device_id}))` or `seam.createPaginator(seam.workspaces.list())` typechecked and failed only at runtime. The accurate `SeamHttpEndpointPaginatedQueryPaths` type existed in codegen output but was consumed by nothing.

## Fix

Pagination support is tracked in a `SeamHttpRequest` type parameter and expressed through a named, exported alias so signatures read as intent rather than an opaque boolean:

```ts
export type SeamPaginatedRequest<TResponse, TResponseKey> =
  SeamHttpRequest<TResponse, TResponseKey, true>

createPaginator<...>(request: SeamPaginatedRequest<TResponse, TResponseKey>): SeamPaginator<...>
```

Generated request types of paginated endpoints are emitted as `SeamPaginatedRequest<...>` (e.g. `DevicesListRequest`), so paginating a non-paginated route is a compile error. Runtime behavior is unchanged — the existing `hasPagination` runtime guard remains for plain-JS callers. The type-parameter default is `boolean`, so existing user code holding `SeamHttpRequest<R, K>` variables keeps compiling everywhere except at the new gate.

## Tests

- new `@ts-expect-error` assertions: `createPaginator(devices.get(...))` and `createPaginator(workspaces.list())` are compile errors (on reverted source, typecheck fails — the audit's symptom that these compiled)
- existing paginator tests and runtime guard test unchanged and green

Regenerated with `npm run generate`. Full suite (154 tests), lint, typecheck green. Merged with latest `main`.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2