### PR TITLE
fix: Export the package root for require

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./index.js"
+      "default": "./index.js"
     },
     "./connect": {
       "types": "./index.d.ts",


### PR DESCRIPTION
## Problem

SDK audit finding L1a (low): the exports map gave `"."` only `types` + `import` conditions, so CommonJS consumers (Jest, webpack CJS, ts-node CJS) got `ERR_PACKAGE_PATH_NOT_EXPORTED` from `require('@seamapi/http')`, while `"./connect"` used `default` and worked. The declared engine (Node ≥22.12) supports `require(esm)`, so the missing condition was the sole blocker — and the README-advertised entry point was the broken one.

## Fix

The root export uses the same `default` condition as `"./connect"`.

## Verification

Built the package and verified end-to-end:

```
old exports: require('@seamapi/http') → ERR_PACKAGE_PATH_NOT_EXPORTED
new exports: require('@seamapi/http') → SeamHttp function; ./connect unchanged
```

Full suite (125 tests) green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_