### PR TITLE
fix: Treat a scheme-less endpoint host as invalid

### DIFF
--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -223,7 +223,7 @@ export class SeamHttpRequest<
 }
 
 const getUrlPrefix = (input: string): string => {
-  if (canParseUrl(input)) {
+  if (isAbsoluteHttpUrl(input)) {
     const url = new URL(input).toString()
     if (url.endsWith('/')) return url.slice(0, -1)
     return url
@@ -239,11 +239,13 @@ const getUrlPrefix = (input: string): string => {
   )
 }
 
-// UPSTREAM: Prefer URL.canParse when it has wider support.
-// https://caniuse.com/mdn-api_url_canparse_static
-const canParseUrl = (input: string): boolean => {
+// An input without an http or https scheme, e.g., localhost:3000,
+// may still parse as a URL with an unintended scheme, e.g., localhost:,
+// and must not be treated as an absolute URL.
+const isAbsoluteHttpUrl = (input: string): boolean => {
   try {
-    return new URL(input) != null
+    const { protocol } = new URL(input)
+    return protocol === 'http:' || protocol === 'https:'
   } catch {
     return false
   }

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -158,6 +158,39 @@ test.serial(
   },
 )
 
+test('SeamHttpRequest: url is a URL when endpoint has an explicit scheme and port', async (t) => {
+  const { seed } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint: 'http://localhost:3000',
+  })
+
+  const { url } = seam.devices.get({ device_id: 'abc123' })
+
+  t.true(url instanceof URL)
+  t.deepEqual(
+    toPlainUrlObject(url),
+    toPlainUrlObject(
+      new URL(
+        'http://localhost:3000/devices/get?device_id=abc123&_strict=true',
+      ),
+    ),
+  )
+})
+
+test.serial(
+  'SeamHttpRequest: url throws for a scheme-less host in a non-browser environment',
+  async (t) => {
+    const { seed } = await getTestServer(t)
+    const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+      endpoint: 'localhost:3000',
+    })
+
+    const request = seam.devices.get({ device_id: 'abc123' })
+
+    t.throws(() => request.url, { message: /Cannot resolve origin/ })
+  },
+)
+
 test.serial(
   'SeamHttpRequest: url throws if unable to resolve origin',
   async (t) => {


### PR DESCRIPTION
## Problem

SDK audit finding L1d (low): `getUrlPrefix` accepted any string the `URL` constructor could parse. `localhost:3000` parses with `localhost:` as the *scheme* (and `3000` as the path), so the request `url` getter built garbage like `localhost:3000/devices/get?x=1` instead of failing.

## Fix

Only `http:`/`https:` URLs are treated as absolute endpoints. Anything else takes the existing fallback path: resolved against the browser origin, or the existing `Cannot resolve origin` error in a non-browser environment.

## Tests

- `endpoint: 'localhost:3000'` → `request.url` throws `Cannot resolve origin` (fails on reverted source, which builds the garbage URL)
- `endpoint: 'http://localhost:3000'` → builds the correct URL

Full suite (127 tests), lint, typecheck green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_