### PR TITLE
fix: Use the object form paramsSerializer in the request url

### DIFF
--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -80,14 +80,7 @@ export class SeamHttpRequest<
   public get url(): URL {
     const { client } = this.#parent
 
-    const { paramsSerializer } = client.defaults
-
-    const serializer =
-      typeof paramsSerializer === 'function'
-        ? paramsSerializer
-        : typeof paramsSerializer?.serialize === 'function'
-          ? paramsSerializer.serialize
-          : serializeUrlSearchParams
+    const serializer = getParamsSerializer(client.defaults.paramsSerializer)
 
     const origin = getUrlPrefix(client.defaults.baseURL ?? '')
 
@@ -224,6 +217,16 @@ export class SeamHttpRequest<
   > {
     return await this.execute().finally(onfinally)
   }
+}
+
+const getParamsSerializer = (
+  paramsSerializer: Client['defaults']['paramsSerializer'],
+): ((params: Record<string, unknown>) => string) => {
+  if (typeof paramsSerializer === 'function') return paramsSerializer
+  if (typeof paramsSerializer?.serialize === 'function') {
+    return paramsSerializer.serialize
+  }
+  return serializeUrlSearchParams
 }
 
 const getUrlPrefix = (input: string): string => {

--- a/src/lib/seam-http-request.ts
+++ b/src/lib/seam-http-request.ts
@@ -80,10 +80,14 @@ export class SeamHttpRequest<
   public get url(): URL {
     const { client } = this.#parent
 
+    const { paramsSerializer } = client.defaults
+
     const serializer =
-      typeof client.defaults.paramsSerializer === 'function'
-        ? client.defaults.paramsSerializer
-        : serializeUrlSearchParams
+      typeof paramsSerializer === 'function'
+        ? paramsSerializer
+        : typeof paramsSerializer?.serialize === 'function'
+          ? paramsSerializer.serialize
+          : serializeUrlSearchParams
 
     const origin = getUrlPrefix(client.defaults.baseURL ?? '')
 

--- a/test/seam/connect/seam-http-request.test.ts
+++ b/test/seam/connect/seam-http-request.test.ts
@@ -172,6 +172,36 @@ test.serial(
   },
 )
 
+test('SeamHttpRequest: url uses a custom function form paramsSerializer', async (t) => {
+  const { seed } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint: 'https://example.com',
+    axiosOptions: {
+      paramsSerializer: () => 'custom=function',
+    },
+  })
+
+  const { url } = seam.devices.get({ device_id: 'abc123' })
+
+  t.is(url.search, '?custom=function')
+})
+
+test('SeamHttpRequest: url uses a custom object form paramsSerializer', async (t) => {
+  const { seed } = await getTestServer(t)
+  const seam = SeamHttp.fromApiKey(seed.seam_apikey1_token, {
+    endpoint: 'https://example.com',
+    axiosOptions: {
+      paramsSerializer: {
+        serialize: () => 'custom=object',
+      },
+    },
+  })
+
+  const { url } = seam.devices.get({ device_id: 'abc123' })
+
+  t.is(url.search, '?custom=object')
+})
+
 const toPlainUrlObject = (url: URL): Omit<URL, 'searchParams' | 'toJSON'> => {
   return {
     pathname: url.pathname,


### PR DESCRIPTION
## Problem

SDK audit finding L8a (low): the `SeamHttpRequest.url` getter only honored a *function*-form `paramsSerializer` and silently fell back to Seam's serializer when the user configured axios's object form (`{ serialize, encode, indexes }`). Axios itself uses the object form when sending, so the inspected `request.url` diverged from the wire URL — debug output lying about the request.

## Fix

The getter now also uses `paramsSerializer.serialize` when the object form is configured, falling back to the SDK serializer only when neither form is present (the SDK default).

## Tests

Both custom forms pinned: a function-form serializer and an object-form serializer each control `request.url`'s query. The object-form test fails on reverted source (falls back to the SDK serializer). Full suite (127 tests), lint, typecheck green.

Part of applying the rev-3 SDK audit (one PR per finding). Related: #1002–#1014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8xeJm2Hd923k8uo6eoFd2)_