### PR TITLE
feat: Generate a status-discriminated action attempt union

### DIFF
--- a/codegen/layouts/partials/resource-object.hbs
+++ b/codegen/layouts/partials/resource-object.hbs
@@ -1,6 +1,6 @@
 {
 {{#each properties}}
   {{> doc}}
-  {{json name}}{{#if isOptional}}?{{/if}}: {{> resource-property-type }}{{#if isNullable}} | null{{/if}}{{#if isOptional}} | undefined{{/if}}
+  {{json name}}{{#if isOptional}}?{{/if}}: {{#if renderAsNull}}null{{else}}{{> resource-property-type }}{{#if isNullable}} | null{{/if}}{{/if}}{{#if isOptional}} | undefined{{/if}}
 {{/each}}
 }

--- a/codegen/lib/layouts/resources.ts
+++ b/codegen/lib/layouts/resources.ts
@@ -1,4 +1,10 @@
-import type { Blueprint, Resource } from '@seamapi/blueprint'
+import type {
+  ActionAttemptStatus,
+  Blueprint,
+  EnumProperty,
+  Property,
+  Resource,
+} from '@seamapi/blueprint'
 import { kebabCase, pascalCase } from 'change-case'
 
 export interface ResourceLayoutContext {
@@ -39,7 +45,7 @@ export const getResourceLayoutContexts = (
       ({ resourceType }) => !discriminatedResourceTypes.has(resourceType),
     ),
     ...blueprint.events,
-    ...blueprint.actionAttempts,
+    ...blueprint.actionAttempts.flatMap(expandActionAttemptByStatus),
   ]
   const resourceTypes = [
     ...new Set(resources.map(({ resourceType }) => resourceType)),
@@ -55,6 +61,44 @@ export const getResourceLayoutContexts = (
     isBatch: resourceType === 'batch',
     batchResources: resourceType === 'batch' ? batchResources : [],
   }))
+}
+
+// Expand an action attempt into one union member per status from its status
+// enum. In each member, the status property is rendered as the status literal,
+// and any property annotated with actionAttemptStatuses is rendered as null
+// for the statuses it does not list.
+const expandActionAttemptByStatus = (resource: Resource): Resource[] => {
+  const statusProperty = resource.properties.find(
+    (property): property is EnumProperty =>
+      property.name === 'status' && property.format === 'enum',
+  )
+  if (statusProperty == null) return [resource]
+
+  return statusProperty.values.map(({ name }) => {
+    const status = name as ActionAttemptStatus
+    return {
+      ...resource,
+      properties: resource.properties.map((property): Property => {
+        if (property === statusProperty) {
+          return {
+            ...statusProperty,
+            values: statusProperty.values.filter(
+              (value) => value.name === status,
+            ),
+          }
+        }
+        const { actionAttemptStatuses } = property
+        if (actionAttemptStatuses == null) return property
+        if (actionAttemptStatuses.includes(status)) return property
+        const nullRenderedProperty: Property & { renderAsNull: true } = {
+          ...property,
+          isNullable: false,
+          renderAsNull: true,
+        }
+        return nullRenderedProperty
+      }),
+    }
+  })
 }
 
 const getBatchResourceLayoutContexts = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios-retry": "^4.4.2"
       },
       "devDependencies": {
-        "@seamapi/blueprint": "^1.9.1",
+        "@seamapi/blueprint": "^1.10.0",
         "@seamapi/fake-seam-connect": "^2.0.4",
         "@seamapi/smith": "^1.1.0",
         "@seamapi/types": "1.1047.0",
@@ -1067,9 +1067,9 @@
       "license": "MIT"
     },
     "node_modules/@seamapi/blueprint": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.9.1.tgz",
-      "integrity": "sha512-A9H3dZE9f+ZEEnOAlMl5jSlL5F/RIKkjOF8NDFbnuahAiu/trDz/RzHOGhbQd6sd0RErIyx3eG1p4HCOJDKDCA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.10.0.tgz",
+      "integrity": "sha512-XyP6zvbhv5naWEa9T9utNLi3FVVmvUB1Htih/IjUqS3Uz0FrIIBWy7Myk5+s4uylEt+wTdtSBaA1fGOF/6ILmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "axios-retry": "^4.4.2"
   },
   "devDependencies": {
-    "@seamapi/blueprint": "^1.9.1",
+    "@seamapi/blueprint": "^1.10.0",
     "@seamapi/fake-seam-connect": "^2.0.4",
     "@seamapi/smith": "^1.1.0",
     "@seamapi/types": "1.1047.0",

--- a/src/lib/resolve-action-attempt.ts
+++ b/src/lib/resolve-action-attempt.ts
@@ -162,13 +162,15 @@ const isFailedActionAttempt = <T extends ActionAttempt>(
 /**
  * An action attempt that has succeeded.
  */
-export type SucceededActionAttempt<T extends ActionAttempt> = T & {
-  status: 'success'
-}
+export type SucceededActionAttempt<T extends ActionAttempt> = Extract<
+  T,
+  { status: 'success' }
+>
 
 /**
  * An action attempt that has failed.
  */
-export type FailedActionAttempt<T extends ActionAttempt> = T & {
-  status: 'error'
-}
+export type FailedActionAttempt<T extends ActionAttempt> = Extract<
+  T,
+  { status: 'error' }
+>

--- a/src/lib/resources/action-attempt.ts
+++ b/src/lib/resources/action-attempt.ts
@@ -21,6 +21,55 @@ export type ActionAttempt =
       /**
        * Error associated with the action.
        */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {
+        /**
+         * Indicates whether the device confirmed that the lock action occurred.
+         */
+        was_confirmed_by_device?: boolean | undefined
+      }
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of locking a door.
+       */
+      action_type: 'LOCK_DOOR'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of locking a door.
+       */
+      action_type: 'LOCK_DOOR'
+
+      /**
+       * Error associated with the action.
+       */
       error: {
         /**
          * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
@@ -36,14 +85,58 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of unlocking a door.
+       */
+      action_type: 'UNLOCK_DOOR'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {
         /**
-         * Indicates whether the device confirmed that the lock action occurred.
+         * Indicates whether the device confirmed that the unlock action occurred.
          */
         was_confirmed_by_device?: boolean | undefined
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of unlocking a door.
+       */
+      action_type: 'UNLOCK_DOOR'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -74,14 +167,9 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {
-        /**
-         * Indicates whether the device confirmed that the unlock action occurred.
-         */
-        was_confirmed_by_device?: boolean | undefined
-      }
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
     }
   | {
       /**
@@ -94,24 +182,7 @@ export type ActionAttempt =
        */
       action_type: 'SCAN_CREDENTIAL'
 
-      error: {
-        /**
-         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
-         */
-        message: string
-
-        /**
-         * Error type to indicate that the Seam Bridge is disconnected or cannot reach the access control system.
-         */
-        type:
-          | 'uncategorized_error'
-          | 'action_attempt_expired'
-          | 'no_credential_on_encoder'
-          | 'encoder_not_online'
-          | 'encoder_communication_timeout'
-          | 'bridge_disconnected'
-      }
-
+      error: null
       /**
        * Result of scanning a card. If the attempt was successful, includes a snapshot of credential data read from the physical encoder, the corresponding data stored on Seam and the access system, and any associated warnings.
        */
@@ -468,7 +539,62 @@ export type ActionAttempt =
         }>
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of scanning a credential.
+       */
+      action_type: 'SCAN_CREDENTIAL'
+
+      error: null
+      /**
+       * Result of scanning a card. If the attempt was successful, includes a snapshot of credential data read from the physical encoder, the corresponding data stored on Seam and the access system, and any associated warnings.
+       */
+      result: null
+
+      status: 'pending'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of scanning a credential.
+       */
+      action_type: 'SCAN_CREDENTIAL'
+
+      error: {
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
+        message: string
+
+        /**
+         * Error type to indicate that the Seam Bridge is disconnected or cannot reach the access control system.
+         */
+        type:
+          | 'uncategorized_error'
+          | 'action_attempt_expired'
+          | 'no_credential_on_encoder'
+          | 'encoder_not_online'
+          | 'encoder_communication_timeout'
+          | 'bridge_disconnected'
+      }
+
+      /**
+       * Result of scanning a card. If the attempt was successful, includes a snapshot of credential data read from the physical encoder, the corresponding data stored on Seam and the access system, and any associated warnings.
+       */
+      result: null
+
+      status: 'error'
     }
   | {
       /**
@@ -481,28 +607,7 @@ export type ActionAttempt =
        */
       action_type: 'ENCODE_CREDENTIAL'
 
-      error: {
-        /**
-         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
-         */
-        message: string
-
-        /**
-         * Error type to indicate that the credential was deleted and can no longer be encoded.
-         */
-        type:
-          | 'uncategorized_error'
-          | 'action_attempt_expired'
-          | 'no_credential_on_encoder'
-          | 'incompatible_card_format'
-          | 'credential_cannot_be_reissued'
-          | 'encoder_not_online'
-          | 'encoder_communication_timeout'
-          | 'bridge_disconnected'
-          | 'encoding_interrupted'
-          | 'credential_deleted'
-      }
-
+      error: null
       /**
        * Result of an encoding attempt. If the attempt was successful, includes the credential data that was encoded onto the card.
        */
@@ -757,7 +862,66 @@ export type ActionAttempt =
         workspace_id: string
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of encoding credential data from the physical encoder onto a card.
+       */
+      action_type: 'ENCODE_CREDENTIAL'
+
+      error: null
+      /**
+       * Result of an encoding attempt. If the attempt was successful, includes the credential data that was encoded onto the card.
+       */
+      result: null
+
+      status: 'pending'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of encoding credential data from the physical encoder onto a card.
+       */
+      action_type: 'ENCODE_CREDENTIAL'
+
+      error: {
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
+        message: string
+
+        /**
+         * Error type to indicate that the credential was deleted and can no longer be encoded.
+         */
+        type:
+          | 'uncategorized_error'
+          | 'action_attempt_expired'
+          | 'no_credential_on_encoder'
+          | 'incompatible_card_format'
+          | 'credential_cannot_be_reissued'
+          | 'encoder_not_online'
+          | 'encoder_communication_timeout'
+          | 'bridge_disconnected'
+          | 'encoding_interrupted'
+          | 'credential_deleted'
+      }
+
+      /**
+       * Result of an encoding attempt. If the attempt was successful, includes the credential data that was encoded onto the card.
+       */
+      result: null
+
+      status: 'error'
     }
   | {
       /**
@@ -770,21 +934,7 @@ export type ActionAttempt =
        */
       action_type: 'SCAN_TO_ASSIGN_CREDENTIAL'
 
-      error: {
-        /**
-         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
-         */
-        message: string
-
-        /**
-         * Error type to indicate that there is no credential on the encoder.
-         */
-        type:
-          | 'uncategorized_error'
-          | 'action_attempt_expired'
-          | 'no_credential_on_encoder'
-      }
-
+      error: null
       /**
        * Result of a scan to assign attempt. If the attempt was successful, includes the credential data that was scanned and assigned.
        */
@@ -1041,7 +1191,59 @@ export type ActionAttempt =
         workspace_id: string
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of scanning a physical card and assigning the credential to an ACS user.
+       */
+      action_type: 'SCAN_TO_ASSIGN_CREDENTIAL'
+
+      error: null
+      /**
+       * Result of a scan to assign attempt. If the attempt was successful, includes the credential data that was scanned and assigned.
+       */
+      result: null
+
+      status: 'pending'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of scanning a physical card and assigning the credential to an ACS user.
+       */
+      action_type: 'SCAN_TO_ASSIGN_CREDENTIAL'
+
+      error: {
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
+        message: string
+
+        /**
+         * Error type to indicate that there is no credential on the encoder.
+         */
+        type:
+          | 'uncategorized_error'
+          | 'action_attempt_expired'
+          | 'no_credential_on_encoder'
+      }
+
+      /**
+       * Result of a scan to assign attempt. If the attempt was successful, includes the credential data that was scanned and assigned.
+       */
+      result: null
+
+      status: 'error'
     }
   | {
       /**
@@ -1054,21 +1256,7 @@ export type ActionAttempt =
        */
       action_type: 'ASSIGN_CREDENTIAL'
 
-      error: {
-        /**
-         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
-         */
-        message: string
-
-        /**
-         * Error type to indicate that no matching credential was found.
-         */
-        type:
-          | 'uncategorized_error'
-          | 'action_attempt_expired'
-          | 'credential_not_found'
-      }
-
+      error: null
       /**
        * Result of assigning a credential. If successful, includes the updated access method with the assigned credential.
        */
@@ -1243,7 +1431,103 @@ export type ActionAttempt =
         workspace_id: string
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of assigning a pre-registered card credential to an access method.
+       */
+      action_type: 'ASSIGN_CREDENTIAL'
+
+      error: null
+      /**
+       * Result of assigning a credential. If successful, includes the updated access method with the assigned credential.
+       */
+      result: null
+
+      status: 'pending'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of assigning a pre-registered card credential to an access method.
+       */
+      action_type: 'ASSIGN_CREDENTIAL'
+
+      error: {
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
+        message: string
+
+        /**
+         * Error type to indicate that no matching credential was found.
+         */
+        type:
+          | 'uncategorized_error'
+          | 'action_attempt_expired'
+          | 'credential_not_found'
+      }
+
+      /**
+       * Result of assigning a credential. If successful, includes the updated access method with the assigned credential.
+       */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of resetting a sandbox workspace.
+       */
+      action_type: 'RESET_SANDBOX_WORKSPACE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {}
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of resetting a sandbox workspace.
+       */
+      action_type: 'RESET_SANDBOX_WORKSPACE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1274,9 +1558,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of setting the fan mode on a thermostat.
+       */
+      action_type: 'SET_FAN_MODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of setting the fan mode on a thermostat.
+       */
+      action_type: 'SET_FAN_MODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1307,9 +1635,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of setting the HVAC mode on a thermostat.
+       */
+      action_type: 'SET_HVAC_MODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of setting the HVAC mode on a thermostat.
+       */
+      action_type: 'SET_HVAC_MODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1340,9 +1712,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of a climate preset activation.
+       */
+      action_type: 'ACTIVATE_CLIMATE_PRESET'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of a climate preset activation.
+       */
+      action_type: 'ACTIVATE_CLIMATE_PRESET'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1373,9 +1789,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of simulating a keypad code entry.
+       */
+      action_type: 'SIMULATE_KEYPAD_CODE_ENTRY'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of simulating a keypad code entry.
+       */
+      action_type: 'SIMULATE_KEYPAD_CODE_ENTRY'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1406,9 +1866,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of simulating a manual lock action using a keypad.
+       */
+      action_type: 'SIMULATE_MANUAL_LOCK_VIA_KEYPAD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of simulating a manual lock action using a keypad.
+       */
+      action_type: 'SIMULATE_MANUAL_LOCK_VIA_KEYPAD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1439,9 +1943,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of pushing thermostat programs.
+       */
+      action_type: 'PUSH_THERMOSTAT_PROGRAMS'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of pushing thermostat programs.
+       */
+      action_type: 'PUSH_THERMOSTAT_PROGRAMS'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1472,9 +2020,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of configuring the auto-lock on a lock.
+       */
+      action_type: 'CONFIGURE_AUTO_LOCK'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Action attempt to track the status of configuring the auto-lock on a lock.
+       */
+      action_type: 'CONFIGURE_AUTO_LOCK'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1505,9 +2097,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Syncing access codes is pending.
+       */
+      action_type: 'SYNC_ACCESS_CODES'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {}
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Syncing access codes is pending.
+       */
+      action_type: 'SYNC_ACCESS_CODES'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1538,9 +2174,58 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {}
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Creating an access code is pending.
+       */
+      action_type: 'CREATE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {
+        /**
+         * Created access code.
+         */
+        access_code: Record<string, unknown>
+      }
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Creating an access code is pending.
+       */
+      action_type: 'CREATE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1571,14 +2256,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {
-        /**
-         * Created access code.
-         */
-        access_code: Record<string, unknown>
-      }
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Deleting an access code is pending.
+       */
+      action_type: 'DELETE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {}
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Deleting an access code is pending.
+       */
+      action_type: 'DELETE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1609,9 +2333,58 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {}
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Updating an access code is pending.
+       */
+      action_type: 'UPDATE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {
+        /**
+         * Updated access code.
+         */
+        access_code?: Record<string, unknown> | undefined
+      }
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Updating an access code is pending.
+       */
+      action_type: 'UPDATE_ACCESS_CODE'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1642,14 +2415,58 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
+      result: null
+
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Creating a noise threshold is pending.
+       */
+      action_type: 'CREATE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
       result: {
         /**
-         * Updated access code.
+         * Created noise threshold.
          */
-        access_code?: Record<string, unknown> | undefined
+        noise_threshold: Record<string, unknown>
       }
 
-      status: 'success' | 'pending' | 'error'
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Creating a noise threshold is pending.
+       */
+      action_type: 'CREATE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1680,14 +2497,53 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {
-        /**
-         * Created noise threshold.
-         */
-        noise_threshold: Record<string, unknown>
-      }
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Deleting a noise threshold is pending.
+       */
+      action_type: 'DELETE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {}
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Deleting a noise threshold is pending.
+       */
+      action_type: 'DELETE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1718,9 +2574,58 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {}
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Updating a noise threshold is pending.
+       */
+      action_type: 'UPDATE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: {
+        /**
+         * Updated noise threshold.
+         */
+        noise_threshold: Record<string, unknown>
+      }
+
+      status: 'success'
+    }
+  | {
+      /**
+       * ID of the action attempt.
+       */
+      action_attempt_id: string
+
+      /**
+       * Updating a noise threshold is pending.
+       */
+      action_type: 'UPDATE_NOISE_THRESHOLD'
+
+      /**
+       * Error associated with the action.
+       */
+      error: null
+      /**
+       * Result of the action.
+       */
+      result: null
+
+      status: 'pending'
     }
   | {
       /**
@@ -1751,12 +2656,7 @@ export type ActionAttempt =
       /**
        * Result of the action.
        */
-      result: {
-        /**
-         * Updated noise threshold.
-         */
-        noise_threshold: Record<string, unknown>
-      }
+      result: null
 
-      status: 'success' | 'pending' | 'error'
+      status: 'error'
     }

--- a/test/seam/connect/action-attempt-types.test.ts
+++ b/test/seam/connect/action-attempt-types.test.ts
@@ -1,0 +1,95 @@
+import test from 'ava'
+
+import type {
+  ActionAttempt,
+  FailedActionAttempt,
+  SucceededActionAttempt,
+} from '@seamapi/http/connect'
+
+import {
+  type ActionAttemptsClient,
+  resolveActionAttempt,
+} from 'lib/resolve-action-attempt.js'
+
+const expectType = <Expected>(_value: Expected): void => {}
+
+type LockDoorActionAttempt = Extract<
+  ActionAttempt,
+  { action_type: 'LOCK_DOOR' }
+>
+
+const assertUnnarrowedDereferenceFails = (
+  actionAttempt: LockDoorActionAttempt,
+): void => {
+  // @ts-expect-error The result is null unless the status is success.
+  expectType<unknown>(actionAttempt.result.was_confirmed_by_device)
+
+  // @ts-expect-error The error is null unless the status is error.
+  expectType<unknown>(actionAttempt.error.message)
+}
+
+test('action attempt result and error cannot be dereferenced without narrowing', (t) => {
+  t.is(typeof assertUnnarrowedDereferenceFails, 'function')
+})
+
+const assertSuccessNarrowing = (actionAttempt: LockDoorActionAttempt): void => {
+  if (actionAttempt.status === 'success') {
+    expectType<boolean | undefined>(
+      actionAttempt.result.was_confirmed_by_device,
+    )
+    expectType<null>(actionAttempt.error)
+  }
+}
+
+test('narrowing on success status needs no null check on result', (t) => {
+  t.is(typeof assertSuccessNarrowing, 'function')
+})
+
+const assertErrorNarrowing = (actionAttempt: LockDoorActionAttempt): void => {
+  if (actionAttempt.status === 'error') {
+    expectType<string>(actionAttempt.error.message)
+    expectType<string>(actionAttempt.error.type)
+    expectType<null>(actionAttempt.result)
+  }
+}
+
+test('narrowing on error status needs no null check on error', (t) => {
+  t.is(typeof assertErrorNarrowing, 'function')
+})
+
+const assertResolvedActionAttemptIsSucceeded = async (
+  actionAttempt: LockDoorActionAttempt,
+  actionAttempts: ActionAttemptsClient,
+): Promise<void> => {
+  const resolved = await resolveActionAttempt(actionAttempt, actionAttempts, {})
+  expectType<SucceededActionAttempt<LockDoorActionAttempt>>(resolved)
+  expectType<'success'>(resolved.status)
+  expectType<boolean | undefined>(resolved.result.was_confirmed_by_device)
+  expectType<null>(resolved.error)
+}
+
+test('waiting for an action attempt returns the extracted success type', (t) => {
+  t.is(typeof assertResolvedActionAttemptIsSucceeded, 'function')
+})
+
+const assertPendingActionAttemptTypes = (
+  actionAttempt: Extract<LockDoorActionAttempt, { status: 'pending' }>,
+): void => {
+  expectType<null>(actionAttempt.error)
+  expectType<null>(actionAttempt.result)
+}
+
+test('pending action attempts type status-dependent values as null', (t) => {
+  t.is(typeof assertPendingActionAttemptTypes, 'function')
+})
+
+const assertFailedActionAttemptHasError = (
+  actionAttempt: FailedActionAttempt<LockDoorActionAttempt>,
+): void => {
+  expectType<string>(actionAttempt.error.message)
+  expectType<null>(actionAttempt.result)
+}
+
+test('failed action attempts type the error as non-null', (t) => {
+  t.is(typeof assertFailedActionAttemptHasError, 'function')
+})


### PR DESCRIPTION
## What this means for SDK users

`ActionAttempt` is now a union with one member per `action_type` × `status`, so TypeScript knows exactly when `error` and `result` are real objects and when they are `null`:

```ts
const attempt = await seam.locks.lockDoor(
  { device_id },
  { waitForActionAttempt: false },
)

// Before: this compiled and crashed at runtime (result is null while pending).
// Now: it does not compile.
attempt.result.was_confirmed_by_device

// Narrow on status — no null checks needed:
if (attempt.status === 'success') {
  attempt.result.was_confirmed_by_device // ok, result is an object here
}
if (attempt.status === 'error') {
  attempt.error.message // ok, error is an object here
}
if (attempt.status === 'pending') {
  attempt.error  // typed null
  attempt.result // typed null
}
```

`SucceededActionAttempt<T>` / `FailedActionAttempt<T>` now actually extract those members:

```ts
type Succeeded = SucceededActionAttempt<ActionAttempt>
// = every { status: 'success' } member, with non-null result
```

Runtime behavior is unchanged — the API always sent `null`; the types just stopped lying about it.

## How

Bumps `@seamapi/blueprint` to ^1.10.0. Blueprint now annotates each action-attempt property with the statuses that populate it (`error` → `['error']`, `result` → `['success']`). Codegen expands each action attempt into one union member per status: `status` becomes the literal, annotated properties keep their type in listed statuses and render as `null` otherwise. Nothing is keyed off the names `error`/`result`. Supersedes #1007.

## Verification

Type-level tests cover the four snippets above plus `resolveActionAttempt` returning the success type. 177 tests, typecheck, lint green. Regeneration from a clean install reproduces the diff exactly; tsc time and editor completion latency are unchanged (generated file 61 KB → 79 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdWS7o3htQ9cNxhCWL5Frp