### PR TITLE
refactor: remove narration comment

### DIFF
--- a/codegen/lib/layouts/resources.ts
+++ b/codegen/lib/layouts/resources.ts
@@ -63,10 +63,6 @@ export const getResourceLayoutContexts = (
   }))
 }
 
-// Expand an action attempt into one union member per status from its status
-// enum. In each member, the status property is rendered as the status literal,
-// and any property annotated with actionAttemptStatuses is rendered as null
-// for the statuses it does not list.
 const expandActionAttemptByStatus = (resource: Resource): Resource[] => {
   const statusProperty = resource.properties.find(
     (property): property is EnumProperty =>


### PR DESCRIPTION
Follow-up to #1022: removes the explanatory comment block above `expandActionAttemptByStatus` in `codegen/lib/layouts/resources.ts`. Comment-only change; no behavior or generated-output difference. Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdWS7o3htQ9cNxhCWL5Frp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdWS7o3htQ9cNxhCWL5Frp)_